### PR TITLE
fix(init fails on Windows): Splitting directory names should use `path.s...

### DIFF
--- a/bin/jasmine.js
+++ b/bin/jasmine.js
@@ -6,4 +6,4 @@ var path = require('path'),
     Jasmine = require('../lib/jasmine.js'),
     jasmine = new Jasmine({ projectBaseDir: path.resolve() });
 
-command.run(jasmine, process.argv);
+command.run(jasmine, process.argv.slice(2));

--- a/lib/command.js
+++ b/lib/command.js
@@ -43,10 +43,7 @@ function Command(projectBaseDir) {
 }
 
 function isFileArg(arg) {
-  return arg !== 'node' &&
-    arg.indexOf('bin/jasmine') === -1 &&
-    arg.indexOf('--') !== 0 &&
-    !isEnvironmentVariable(arg);
+  return arg.indexOf('--') !== 0 && !isEnvironmentVariable(arg);
 }
 
 function parseOptions(argv) {

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -122,7 +122,7 @@ describe('command', function() {
     });
 
     it('should be able to run only specified specs', function() {
-      command.run(fakeJasmine, ['node', 'bin/jasmine.js', 'spec/some/fileSpec.js', 'SOME_ENV=SOME_VALUE', '--some-option']);
+      command.run(fakeJasmine, ['spec/some/fileSpec.js', 'SOME_ENV=SOME_VALUE', '--some-option']);
       expect(fakeJasmine.execute).toHaveBeenCalledWith(['spec/some/fileSpec.js']);
     });
   });


### PR DESCRIPTION
...ep`.

Node handles the Unix/Windows directory separators but if you are doing path decomposition
by hand then you should use path.sep.
