### PR TITLE
Remove jasmine interal function calls from stack.

### DIFF
--- a/lib/console_reporter.js
+++ b/lib/console_reporter.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 module.exports = exports = ConsoleReporter;
 
 var noopTimer = {
@@ -123,6 +125,14 @@ function ConsoleReporter(options) {
     return newArr.join('\n');
   }
 
+  function filterStack(stack) {
+    var jasminePath = path.join(__dirname, '..', 'node_modules', 'jasmine-core', 'lib', 'jasmine-core', 'jasmine.js');
+    var filteredStack = stack.split('\n').filter(function(stackLine) {
+      return stackLine.indexOf(jasminePath) === -1;
+    }).join('\n');
+    return filteredStack;
+  }
+
   function specFailureDetails(result) {
     printNewline();
     print(result.fullName);
@@ -131,7 +141,7 @@ function ConsoleReporter(options) {
       var failedExpectation = result.failedExpectations[i];
       printNewline();
       print(indent(failedExpectation.message, 2));
-      print(indent(failedExpectation.stack, 2));
+      print(indent(filterStack(failedExpectation.stack), 2));
     }
 
     printNewline();

--- a/spec/console_reporter_spec.js
+++ b/spec/console_reporter_spec.js
@@ -1,6 +1,13 @@
 describe("ConsoleReporter", function() {
   var out,
-    ConsoleReporter = require('../lib/console_reporter');
+    path = require('path'),
+    ConsoleReporter = require('../lib/console_reporter'),
+    jasmineCorePath = path.join(__dirname, '..', 'node_modules', 'jasmine-core', 'lib', 'jasmine-core', 'jasmine.js');
+
+  var fakeStack = ['foo' + jasmineCorePath,
+    'bar ' + jasmineCorePath,
+    'line of useful stack trace',
+    'baz ' + jasmineCorePath].join('\n');
 
   beforeEach(function() {
     out = (function() {
@@ -133,7 +140,7 @@ describe("ConsoleReporter", function() {
           message: "Expected true to be false.",
           expected: false,
           actual: true,
-          stack: "foo\nbar\nbaz"
+          stack: fakeStack
         }
       ]
     });
@@ -148,7 +155,7 @@ describe("ConsoleReporter", function() {
     expect(out.getOutput()).toMatch("Finished in 0.1 seconds\n");
   });
 
-  it("reports a summary when done that includes stack traces for a failing suite", function() {
+  it("reports a summary when done that includes stack traces without jasmine interals for a failing suite", function() {
     var reporter = new ConsoleReporter({
       print: out.print
     });
@@ -165,7 +172,7 @@ describe("ConsoleReporter", function() {
           message: "Expected true to be false.",
           expected: false,
           actual: true,
-          stack: "foo bar baz"
+          stack: fakeStack
         }
       ]
     });
@@ -175,7 +182,8 @@ describe("ConsoleReporter", function() {
     reporter.jasmineDone();
 
     expect(out.getOutput()).toMatch(/true to be false/);
-    expect(out.getOutput()).toMatch(/foo bar baz/);
+    expect(out.getOutput()).toMatch(/line of useful stack trace/);
+    expect(out.getOutput()).not.toMatch(jasmineCorePath);
   });
 
   describe('onComplete callback', function(){


### PR DESCRIPTION
This fixes the stack trace verboseness part of #4.
