### PR TITLE
Implement --no-default-reporter option

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -48,16 +48,20 @@ function isFileArg(arg) {
 
 function parseOptions(argv) {
   var files = [],
-      color = true;
+      color = true,
+      useDefaultReporter = true;
   argv.forEach(function(arg) {
     if (arg === '--no-color') {
       color = false;
+    } else if (arg === '--no-default-reporter') {
+      useDefaultReporter = false;
     } else if (isFileArg(arg)) {
       files.push(arg);
     }
   });
   return {
     color: color,
+    useDefaultReporter: useDefaultReporter,
     files: files
   };
 }
@@ -65,9 +69,11 @@ function parseOptions(argv) {
 function runJasmine(jasmine, env) {
   jasmine.loadConfigFile(process.env.JASMINE_CONFIG_PATH);
 
-  jasmine.configureDefaultReporter({
-    showColors: env.color
-  });
+  if (env.useDefaultReporter) {
+    jasmine.configureDefaultReporter({
+      showColors: env.color
+    });
+  }
   jasmine.execute(env.files);
 }
 

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -114,6 +114,16 @@ describe('command', function() {
       expect(this.fakeJasmine.configureDefaultReporter).toHaveBeenCalledWith({ showColors: false });
     });
 
+    it('should add a reporter by default', function() {
+      this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js']);
+      expect(this.fakeJasmine.configureDefaultReporter).toHaveBeenCalled();
+    });
+
+    it('should allow not to use a default reporter', function() {
+      this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--no-default-reporter']);
+      expect(this.fakeJasmine.configureDefaultReporter).not.toHaveBeenCalled();
+    });
+
     it('should execute the jasmine suite', function() {
       this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js']);
       expect(this.fakeJasmine.execute).toHaveBeenCalled();


### PR DESCRIPTION
This option would allow to use reporters other than the console reporter and prevent errors like #20 / #21.

With the PR we will be able to use reporters like JUnitXmlReporter (in the jasmine-reporters package) that now does not work because the default reportes calls `exit()` in the `jasmineDone` event callback.