### PR TITLE
Don't output ANSI escape sequences if stdout is not a terminal

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -48,7 +48,7 @@ function isFileArg(arg) {
 
 function parseOptions(argv) {
   var files = [],
-      color = true;
+      color = process.stdout.isTTY || false;
   argv.forEach(function(arg) {
     if (arg === '--no-color') {
       color = false;

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -86,6 +86,16 @@ describe('command', function() {
   });
 
   describe('running specs', function() {
+    var withValueForIsTTY = function(value, func) {
+      var wasTTY = process.stdout.isTTY;
+      try {
+        process.stdout.isTTY = value;
+        func();
+      } finally {
+        process.stdout.isTTY = wasTTY;
+      }
+    };
+
     beforeEach(function() {
       this.originalConfigPath = process.env.JASMINE_CONFIG_PATH;
     });
@@ -104,9 +114,18 @@ describe('command', function() {
       expect(this.fakeJasmine.loadConfigFile).toHaveBeenCalledWith('somewhere.json');
     });
 
-    it('should show colors by default', function() {
-      this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js']);
-      expect(this.fakeJasmine.showColors).toHaveBeenCalledWith(true);
+    it('should show colors by default if stdout is a TTY', function() {
+      withValueForIsTTY(true, function () {
+        this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js']);
+        expect(this.fakeJasmine.showColors).toHaveBeenCalledWith(true);
+      }.bind(this));
+    });
+
+    it('should not show colors by default if stdout is not a TTY', function() {
+      withValueForIsTTY(undefined, function () {
+        this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js']);
+        expect(this.fakeJasmine.showColors).toHaveBeenCalledWith(false);
+      }.bind(this));
     });
 
     it('should allow colors to be turned off', function() {


### PR DESCRIPTION
Jasmine's output is a bit of a mess when it's piped or redirected. Although users can already get around the problem by passing --no-color, a well-behaved command line program should take care of this sort of thing automatically.

Here's what piping to less looks like before this change:

```Started
ESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.
ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.
ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.
ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.ESC[0mESC[32m.
ESC[0mESC[32m.ESC[0m


58 specs, 0 failures
Finished in 0.158 seconds
```

And after:

```Started
...........................................................


59 specs, 0 failures
Finished in 0.141 seconds
```