### PR TITLE
Add filter by spec name

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -48,16 +48,21 @@ function isFileArg(arg) {
 
 function parseOptions(argv) {
   var files = [],
-      color = process.stdout.isTTY || false;
+      color = process.stdout.isTTY || false,
+      filter;
   argv.forEach(function(arg) {
     if (arg === '--no-color') {
       color = false;
-    } else if (isFileArg(arg)) {
+    } else if (arg.match("^--filter=")) {
+      filter = arg.match("^--filter=(.*)")[1];
+    }
+    else if (isFileArg(arg)) {
       files.push(arg);
     }
   });
   return {
     color: color,
+    filter: filter,
     files: files
   };
 }
@@ -66,7 +71,7 @@ function runJasmine(jasmine, env) {
   jasmine.loadConfigFile(process.env.JASMINE_CONFIG_PATH);
 
   jasmine.showColors(env.color);
-  jasmine.execute(env.files);
+  jasmine.execute(env.files, env.filter);
 }
 
 function initJasmine(options) {

--- a/lib/filters/console_spec_filter.js
+++ b/lib/filters/console_spec_filter.js
@@ -1,0 +1,10 @@
+module.exports = exports = ConsoleSpecFilter;
+
+function ConsoleSpecFilter(options) {
+  var filterString = options && options.filterString && options.filterString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+  var filterPattern = new RegExp(filterString);
+
+  this.matches = function(specName) {
+    return filterPattern.test(specName);
+  };
+}

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -2,7 +2,8 @@ var path = require('path'),
     util = require('util'),
     glob = require('glob'),
     exit = require('exit'),
-    ExitCodeReporter = require('./reporters/exit_code_reporter');
+    ExitCodeReporter = require('./reporters/exit_code_reporter'),
+    ConsoleSpecFilter = require('./filters/console_spec_filter');
 
 module.exports = Jasmine;
 module.exports.ConsoleReporter = require('./reporters/console_reporter');
@@ -112,11 +113,20 @@ Jasmine.prototype.onComplete = function(onCompleteCallback) {
   this.onCompleteCallbackAdded = true;
 };
 
-Jasmine.prototype.execute = function(files) {
+Jasmine.prototype.execute = function(files, filterString) {
   this.loadHelpers();
 
   if(this.reportersCount === 0) {
     this.configureDefaultReporter({ showColors: this.showingColors });
+  }
+
+  if(filterString) {
+    var specFilter = new ConsoleSpecFilter({
+      filterString: filterString
+    });
+    this.env.specFilter = function(spec) {
+      return specFilter.matches(spec.getFullName());
+    };
   }
 
   if (files && files.length > 0) {

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -140,7 +140,12 @@ describe('command', function() {
 
     it('should be able to run only specified specs', function() {
       this.command.run(this.fakeJasmine, ['spec/some/fileSpec.js', 'SOME_ENV=SOME_VALUE', '--some-option']);
-      expect(this.fakeJasmine.execute).toHaveBeenCalledWith(['spec/some/fileSpec.js']);
+      expect(this.fakeJasmine.execute).toHaveBeenCalledWith(['spec/some/fileSpec.js'], undefined);
+    });
+
+    it('should be able filter by spec name', function() {
+      this.command.run(this.fakeJasmine, ['--filter=interesting spec']);
+      expect(this.fakeJasmine.execute).toHaveBeenCalledWith(jasmine.any(Array), 'interesting spec');
     });
   });
 });

--- a/spec/filters/console_spec_filter_spec.js
+++ b/spec/filters/console_spec_filter_spec.js
@@ -1,0 +1,30 @@
+var ConsoleSpecFilter = require('../../lib/filters/console_spec_filter');
+
+describe("ConsoleSpecFilter", function() {
+
+  it("should match when no string is provided", function() {
+    var specFilter = new ConsoleSpecFilter();
+
+    expect(specFilter.matches("foo")).toBe(true);
+    expect(specFilter.matches("*bar")).toBe(true);
+  });
+
+  it("should match the provided string", function() {
+    var specFilter = new ConsoleSpecFilter({
+      filterString: "foo"
+    });
+
+    expect(specFilter.matches("foo")).toBe(true);
+    expect(specFilter.matches("bar")).toBe(false);
+  });
+
+  it("should match by part of spec name", function() {
+    var specFilter = new ConsoleSpecFilter({
+      filterString: "ba"
+    });
+
+    expect(specFilter.matches("foo")).toBe(false);
+    expect(specFilter.matches("bar")).toBe(true);
+    expect(specFilter.matches("baz")).toBe(true);
+  });
+});

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -239,6 +239,13 @@ describe('Jasmine', function() {
       expect(relativePaths).toEqual(['/fixtures/sample_project/spec/fixture_spec.js', '/fixtures/sample_project/spec/other_fixture_spec.js']);
     });
 
+    it('should add spec filter if filterString is provided', function() {
+      this.testJasmine.loadConfigFile();
+
+      this.testJasmine.execute(['spec/fixtures/**/*spec.js'], 'interesting spec');
+      expect(this.testJasmine.env.specFilter).toEqual(jasmine.any(Function));
+    });
+
     it('adds an exit code reporter', function() {
       var exitCodeReporterSpy = jasmine.createSpyObj('reporter', ['onComplete']);
       this.testJasmine.exitCodeReporter = exitCodeReporterSpy;

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -3,7 +3,8 @@
   "spec_files": [
     "command_spec.js",
     "jasmine_spec.js",
-    "reporters/**/*[sS]pec.js"
+    "reporters/**/*[sS]pec.js",
+    "filters/**/*[sS]pec.js"
   ],
   "helpers": [
     "helpers/**/*.js"


### PR DESCRIPTION
That is exactly looks like [HtmlSpecsFilter](https://github.com/jasmine/jasmine/blob/master/src/html/HtmlSpecFilter.js) does.

Usage example:

```
jasmine --filter="some spec"
```

It's better than already existing filtering by file, because it allows to extract some specs from instead of whole file.