### PR TITLE
Report "Ran X of Y specs" if some are disabled.

### DIFF
--- a/lib/reporters/console_reporter.js
+++ b/lib/reporters/console_reporter.js
@@ -12,6 +12,7 @@ function ConsoleReporter(options) {
     jasmineCorePath = options.jasmineCorePath,
     printDeprecation = options.printDeprecation || require('../printDeprecation'),
     specCount,
+    executableSpecCount,
     failureCount,
     failedSpecs = [],
     pendingSpecs = [],
@@ -31,6 +32,7 @@ function ConsoleReporter(options) {
 
   this.jasmineStarted = function() {
     specCount = 0;
+    executableSpecCount = 0;
     failureCount = 0;
     print('Started');
     printNewline();
@@ -57,7 +59,11 @@ function ConsoleReporter(options) {
     if(specCount > 0) {
       printNewline();
 
-      var specCounts = specCount + ' ' + plural('spec', specCount) + ', ' +
+      if(executableSpecCount !== specCount) {
+        print('Ran ' + executableSpecCount + ' of ' + specCount + plural(' spec', specCount));
+        printNewline();
+      }
+      var specCounts = executableSpecCount + ' ' + plural('spec', executableSpecCount) + ', ' +
         failureCount + ' ' + plural('failure', failureCount);
 
       if (pendingSpecs.length) {
@@ -86,11 +92,13 @@ function ConsoleReporter(options) {
 
     if (result.status == 'pending') {
       pendingSpecs.push(result);
+      executableSpecCount++;
       print(colored('yellow', '*'));
       return;
     }
 
     if (result.status == 'passed') {
+      executableSpecCount++;
       print(colored('green', '.'));
       return;
     }
@@ -98,6 +106,7 @@ function ConsoleReporter(options) {
     if (result.status == 'failed') {
       failureCount++;
       failedSpecs.push(result);
+      executableSpecCount++;
       print(colored('red', 'F'));
     }
   };

--- a/spec/reporters/console_reporter_spec.js
+++ b/spec/reporters/console_reporter_spec.js
@@ -126,6 +126,7 @@ describe("ConsoleReporter", function() {
     this.out.clear();
     reporter.jasmineDone();
 
+    expect(this.out.getOutput()).not.toMatch(/Ran 1/);
     expect(this.out.getOutput()).toMatch(/1 spec, 0 failures/);
     expect(this.out.getOutput()).not.toMatch(/0 pending specs/);
     expect(this.out.getOutput()).toMatch("Finished in 1 second\n");
@@ -164,6 +165,26 @@ describe("ConsoleReporter", function() {
 
     expect(this.out.getOutput()).toMatch(/3 specs, 1 failure, 1 pending spec/);
     expect(this.out.getOutput()).toMatch("Finished in 0.1 seconds\n");
+  });
+
+  it("reports a summary when done that indicates the number of specs run (when it's less that the full number of specs)", function() {
+    var timerSpy = jasmine.createSpyObj('timer', ['start', 'elapsed']),
+        reporter = new ConsoleReporter({
+          print: this.out.print,
+          timer: timerSpy
+        });
+
+    reporter.jasmineStarted();
+    reporter.specDone({status: "passed"});
+    reporter.specDone({status: "disabled"});
+
+    timerSpy.elapsed.and.returnValue(1000);
+
+    this.out.clear();
+    reporter.jasmineDone();
+
+    expect(this.out.getOutput()).toMatch(/Ran 1 of 2 specs/);
+    expect(this.out.getOutput()).toMatch(/1 spec, 0 failures/);
   });
 
   it("reports a summary when done that includes the failed spec number before the full name of a failing spec", function() {


### PR DESCRIPTION
Related to https://github.com/jasmine/jasmine-npm/issues/45.

If there are any disabled specs (or, more accurately, specs which are not passed, failed, or pending) then report line `Ran X of Y specs`, like the ruby gem reporter.