### PR TITLE
use JASMINE_CONFIG_PATH env in grunt task

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
     var jasmine = new Jasmine();
     var done = this.async();
 
-    jasmine.loadConfigFile('./spec/support/jasmine.json');
+    jasmine.loadConfigFile(process.env.JASMINE_CONFIG_PATH || './spec/support/jasmine.json');
     jasmine.onComplete(done);
     jasmine.execute();
   });


### PR DESCRIPTION
in order to follow the same API as the executable