### PR TITLE
version bump to 2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bdd"
   ],
   "license": "MIT",
-  "version": "2.3.1",
+  "version": "2.3.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/jasmine/jasmine-npm"
@@ -20,7 +20,7 @@
   "dependencies": {
     "exit": "^0.1.2",
     "glob": "^3.2.11",
-    "jasmine-core": "~2.3.0"
+    "jasmine-core": "~2.3.4"
   },
   "bin": "./bin/jasmine.js",
   "main": "./lib/jasmine.js",


### PR DESCRIPTION
There is a hotfix in jasmine 2.3.3 release that fixes a regression with the execution context for beforeAll. 
Please refer to the details to https://github.com/jasmine/jasmine/blob/master/release_notes/2.3.3.md