### PR TITLE
Enable the --random and --seed cli flags

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -59,17 +59,22 @@ function parseOptions(argv) {
   var files = [],
       color = process.stdout.isTTY || false,
       filter,
-      stopOnFailure;
+      stopOnFailure,
+      random = false,
+      seed;
+
   argv.forEach(function(arg) {
     if (arg === '--no-color') {
       color = false;
     } else if (arg.match("^--filter=")) {
       filter = arg.match("^--filter=(.*)")[1];
-    }
-    else if (arg.match("^--stop-on-failure=")) {
+    } else if (arg.match("^--stop-on-failure=")) {
       stopOnFailure = arg.match("^--stop-on-failure=(.*)")[1] === 'true';
-    }
-    else if (isFileArg(arg)) {
+    } else if (arg.match("^--random=")) {
+      random = arg.match("^--random=(.*)")[1] === 'true';
+    } else if (arg.match("^--seed=")) {
+      seed = arg.match("^--seed=(.*)")[1];
+    } else if (isFileArg(arg)) {
       files.push(arg);
     }
   });
@@ -77,7 +82,9 @@ function parseOptions(argv) {
     color: color,
     filter: filter,
     stopOnFailure: stopOnFailure,
-    files: files
+    files: files,
+    random: random,
+    seed: seed
   };
 }
 
@@ -86,7 +93,11 @@ function runJasmine(jasmine, env) {
   if (env.stopOnFailure !== undefined) {
     jasmine.stopSpecOnExpectationFailure(env.stopOnFailure);
   }
+  if (env.seed !== undefined) {
+    jasmine.seed(env.seed);
+  }
 
+  jasmine.randomizeTests(env.random);
   jasmine.showColors(env.color);
   jasmine.execute(env.files, env.filter);
 }

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -25,6 +25,14 @@ function Jasmine(options) {
   this.showingColors = true;
 }
 
+Jasmine.prototype.randomizeTests = function(value) {
+  this.env.randomizeTests(value);
+};
+
+Jasmine.prototype.seed = function(value) {
+  this.env.seed(value);
+};
+
 Jasmine.prototype.showColors = function(value) {
   this.showingColors = value;
 };
@@ -92,6 +100,7 @@ Jasmine.prototype.loadConfig = function(config) {
   }
 
   this.env.throwOnExpectationFailure(config.stopSpecOnExpectationFailure);
+  this.env.randomizeTests(config.random);
 
   if(config.spec_files) {
     jasmineRunner.addSpecFiles(config.spec_files);

--- a/lib/reporters/console_reporter.js
+++ b/lib/reporters/console_reporter.js
@@ -39,7 +39,7 @@ function ConsoleReporter(options) {
     timer.start();
   };
 
-  this.jasmineDone = function() {
+  this.jasmineDone = function(result) {
     printNewline();
     printNewline();
     if(failedSpecs.length > 0) {
@@ -82,6 +82,11 @@ function ConsoleReporter(options) {
 
     for(i = 0; i < failedSuites.length; i++) {
       suiteFailureDetails(failedSuites[i]);
+    }
+
+    if (result && result.order && result.order.random) {
+      print('Randomized with seed ' + result.order.seed);
+      printNewline();
     }
 
     onComplete(failureCount === 0);

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -42,7 +42,7 @@ describe('command', function() {
 
     this.command = new Command(projectBaseDir, examplesDir, this.out.print);
 
-    this.fakeJasmine = jasmine.createSpyObj('jasmine', ['loadConfigFile', 'showColors', 'execute', 'stopSpecOnExpectationFailure']);
+    this.fakeJasmine = jasmine.createSpyObj('jasmine', ['loadConfigFile', 'showColors', 'execute', 'stopSpecOnExpectationFailure', 'randomizeTests', 'seed']);
   });
 
   afterEach(function() {
@@ -206,6 +206,31 @@ describe('command', function() {
     it('should be able to turn off stopping spec on expectation failure', function() {
       this.command.run(this.fakeJasmine, ['--stop-on-failure=false']);
       expect(this.fakeJasmine.stopSpecOnExpectationFailure).toHaveBeenCalledWith(false);
+    });
+
+    it('should not use random tests by default', function() {
+      this.command.run(this.fakeJasmine, []);
+      expect(this.fakeJasmine.randomizeTests).toHaveBeenCalledWith(false);
+    });
+
+    it('should be able to turn on random tests', function() {
+      this.command.run(this.fakeJasmine, ['--random=true']);
+      expect(this.fakeJasmine.randomizeTests).toHaveBeenCalledWith(true);
+    });
+
+    it('should be able to turn on random tests', function() {
+      this.command.run(this.fakeJasmine, ['--random=true']);
+      expect(this.fakeJasmine.randomizeTests).toHaveBeenCalledWith(true);
+    });
+
+    it('should not configure seed by default', function() {
+      this.command.run(this.fakeJasmine, []);
+      expect(this.fakeJasmine.seed).not.toHaveBeenCalled();
+    });
+
+    it('should be able to set a seed', function() {
+      this.command.run(this.fakeJasmine, ['--seed=12345']);
+      expect(this.fakeJasmine.seed).toHaveBeenCalledWith('12345');
     });
   });
 });

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -8,7 +8,8 @@ describe('Jasmine', function() {
       getEnv: jasmine.createSpy('getEnv').and.returnValue({
         addReporter: jasmine.createSpy('addReporter'),
         execute: jasmine.createSpy('execute'),
-        throwOnExpectationFailure: jasmine.createSpy('throwOnExpectationFailure')
+        throwOnExpectationFailure: jasmine.createSpy('throwOnExpectationFailure'),
+        randomizeTests: jasmine.createSpy('randomizeTests')
       }),
       Timer: jasmine.createSpy('Timer'),
       Expectation: {
@@ -148,6 +149,19 @@ describe('Jasmine', function() {
 
         expect(this.fixtureJasmine.env.throwOnExpectationFailure).toHaveBeenCalledWith(undefined);
       });
+
+      it('can tell jasmine-core to run random specs', function() {
+        this.configObject.random = true;
+        this.fixtureJasmine.loadConfig(this.configObject);
+
+        expect(this.fixtureJasmine.env.randomizeTests).toHaveBeenCalledWith(true);
+      });
+
+      it('tells jasmine-core not to not run random specs by default', function() {
+        this.fixtureJasmine.loadConfig(this.configObject);
+
+        expect(this.fixtureJasmine.env.randomizeTests).toHaveBeenCalledWith(undefined);
+      });
     });
 
     describe('from a file', function() {
@@ -183,6 +197,13 @@ describe('Jasmine', function() {
     it('sets the throwOnExpectationFailure value on the jasmine-core env', function() {
       this.testJasmine.stopSpecOnExpectationFailure('foobar');
       expect(this.testJasmine.env.throwOnExpectationFailure).toHaveBeenCalledWith('foobar');
+    });
+  });
+
+  describe('#randomizeTests', function() {
+    it('sets the randomizeTests value on the jasmine-core env', function() {
+      this.testJasmine.randomizeTests('foobar');
+      expect(this.testJasmine.env.randomizeTests).toHaveBeenCalledWith('foobar');
     });
   });
 

--- a/spec/reporters/console_reporter_spec.js
+++ b/spec/reporters/console_reporter_spec.js
@@ -111,6 +111,21 @@ describe("ConsoleReporter", function() {
     expect(this.out.getOutput()).toMatch(/No specs found/);
   });
 
+  it("reports the seed number when running in random order", function(){
+    var reporter = new ConsoleReporter({
+      print: this.out.print
+    });
+
+    reporter.jasmineDone({
+      order: {
+        random: true,
+        seed: '12345'
+      }
+    });
+
+    expect(this.out.getOutput()).toMatch(/Randomized with seed 12345/);
+  });
+
   it("reports a summary when done (singular spec and time)", function() {
     var timerSpy = jasmine.createSpyObj('timer', ['start', 'elapsed']),
         reporter = new ConsoleReporter({


### PR DESCRIPTION
This is a follow up of jasmine/jasmine#927 it enables the `--random` and `--seed` flags in the cli.
A `random` option is also loaded from jasmine.json for these who want to change the default behaviour and use random tests by default.