### PR TITLE
jasmine.randomizeTests have to just be called when --random option is…

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -60,7 +60,7 @@ function parseOptions(argv) {
       color = process.stdout.isTTY || false,
       filter,
       stopOnFailure,
-      random = false,
+      random,
       seed;
 
   argv.forEach(function(arg) {
@@ -96,8 +96,9 @@ function runJasmine(jasmine, env) {
   if (env.seed !== undefined) {
     jasmine.seed(env.seed);
   }
-
-  jasmine.randomizeTests(env.random);
+  if (env.random !== undefined) {
+    jasmine.randomizeTests(env.random);
+  }
   jasmine.showColors(env.color);
   jasmine.execute(env.files, env.filter);
 }

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -214,12 +214,17 @@ describe('command', function() {
 
     it('should not use random tests by default', function() {
       this.command.run(this.fakeJasmine, []);
-      expect(this.fakeJasmine.randomizeTests).toHaveBeenCalledWith(false);
+      expect(this.fakeJasmine.randomizeTests).not.toHaveBeenCalled();
     });
 
     it('should be able to turn on random tests', function() {
       this.command.run(this.fakeJasmine, ['--random=true']);
       expect(this.fakeJasmine.randomizeTests).toHaveBeenCalledWith(true);
+    });
+
+    it('should be able to turn off random tests', function() {
+      this.command.run(this.fakeJasmine, ['--random=false']);
+      expect(this.fakeJasmine.randomizeTests).toHaveBeenCalledWith(false);
     });
 
     it('should not configure seed by default', function() {


### PR DESCRIPTION
… passed

Previously in #55, I added support for the random option, the idea was to support this both in cli via `--random=true` or jasmine.json config with `"random": true`. But I notice that passing this option to the config file never worked as expected. Because the random option by default was always being set to false, behaving like `--random=false` in cli and disabling the random feature when set in the config file.
This PR changes the default value from random to undefined, so we can check if the user explicitly passed the --random option and call `jasmine.randomizeTests` with the correct value.