### PR TITLE
Changes the default report configuration, using fallback instead

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -18,7 +18,6 @@ function Jasmine(options) {
   this.specFiles = [];
   this.helperFiles = [];
   this.env = this.jasmine.getEnv();
-  this.reportersCount = 0;
   this.exitCodeReporter = new ExitCodeReporter();
   this.onCompleteCallbackAdded = false;
   this.exit = exit;
@@ -43,7 +42,10 @@ Jasmine.prototype.addSpecFile = function(filePath) {
 
 Jasmine.prototype.addReporter = function(reporter) {
   this.env.addReporter(reporter);
-  this.reportersCount++;
+};
+
+Jasmine.prototype.provideFallbackReporter = function(reporter) {
+  this.env.provideFallbackReporter(reporter);
 };
 
 Jasmine.prototype.configureDefaultReporter = function(options) {
@@ -58,7 +60,7 @@ Jasmine.prototype.configureDefaultReporter = function(options) {
     this.printDeprecation('Passing in an onComplete function to configureDefaultReporter is deprecated.');
   }
   var consoleReporter = new module.exports.ConsoleReporter(options);
-  this.addReporter(consoleReporter);
+  this.provideFallbackReporter(consoleReporter);
   this.defaultReporterAdded = true;
 };
 
@@ -131,10 +133,7 @@ Jasmine.prototype.stopSpecOnExpectationFailure = function(value) {
 
 Jasmine.prototype.execute = function(files, filterString) {
   this.loadHelpers();
-
-  if(this.reportersCount === 0) {
-    this.configureDefaultReporter({ showColors: this.showingColors });
-  }
+  this.configureDefaultReporter({ showColors: this.showingColors });
 
   if(filterString) {
     var specFilter = new ConsoleSpecFilter({

--- a/spec/helpers/console_reporter.js
+++ b/spec/helpers/console_reporter.js
@@ -1,0 +1,9 @@
+var util = require('util');
+var options = {
+    showColors: true,
+    print: function() {
+        process.stdout.write(util.format.apply(this, arguments));
+    }
+};
+
+jasmine.getEnv().addReporter(new jasmine.ConsoleReporter(options));

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -7,6 +7,7 @@ describe('Jasmine', function() {
     this.bootedJasmine = {
       getEnv: jasmine.createSpy('getEnv').and.returnValue({
         addReporter: jasmine.createSpy('addReporter'),
+        provideFallbackReporter: jasmine.createSpy('provideFallbackReporter'),
         execute: jasmine.createSpy('execute'),
         throwOnExpectationFailure: jasmine.createSpy('throwOnExpectationFailure'),
         randomizeTests: jasmine.createSpy('randomizeTests')
@@ -60,7 +61,7 @@ describe('Jasmine', function() {
       this.testJasmine.configureDefaultReporter(reporterOptions);
 
       expect(Jasmine.ConsoleReporter).toHaveBeenCalledWith(expectedReporterOptions);
-      expect(this.testJasmine.env.addReporter).toHaveBeenCalledWith({someProperty: 'some value'});
+      expect(this.testJasmine.env.provideFallbackReporter).toHaveBeenCalledWith({someProperty: 'some value'});
     });
 
     it('creates a reporter with a default option if an option is not specified', function() {
@@ -76,7 +77,7 @@ describe('Jasmine', function() {
       };
 
       expect(Jasmine.ConsoleReporter).toHaveBeenCalledWith(expectedReporterOptions);
-      expect(this.testJasmine.env.addReporter).toHaveBeenCalledWith({someProperty: 'some value'});
+      expect(this.testJasmine.env.provideFallbackReporter).toHaveBeenCalledWith({someProperty: 'some value'});
     });
 
     it('sets the defaultReporterAdded flag', function() {
@@ -269,15 +270,16 @@ describe('Jasmine', function() {
       expect(this.testJasmine.env.execute).toHaveBeenCalled();
     });
 
-    it('does not add a default reporter if a reporter was already added', function() {
+    it('adds a default reporter as a fallback reporter', function() {
       this.testJasmine.addReporter(new Jasmine.ConsoleReporter({}));
 
-      spyOn(this.testJasmine, 'configureDefaultReporter');
+      //spyOn(this.testJasmine, 'configureDefaultReporter');
       spyOn(this.testJasmine, 'loadSpecs');
 
       this.testJasmine.execute();
 
-      expect(this.testJasmine.configureDefaultReporter).not.toHaveBeenCalled();
+      expect(this.testJasmine.env.provideFallbackReporter).toHaveBeenCalled();
+      expect(this.testJasmine.env.addReporter).toHaveBeenCalled();
       expect(this.testJasmine.loadSpecs).toHaveBeenCalled();
       expect(this.testJasmine.env.execute).toHaveBeenCalled();
     });


### PR DESCRIPTION
Hi there,

I've opened  https://github.com/jasmine/jasmine/pull/1009 in jasmine-core to allow configuring a fallback report in case there's no report configured. It would allow configuring a reporter in a helper as follows:

```node
jasmine.getEnv().addReporter(myReporter);
```

It would deal with issue #66 opened by myself.

Sorry if I've missed something. Thanks and regards!