### PR TITLE
fix: Makes `spec_dir` optional

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -86,7 +86,7 @@ Jasmine.prototype.loadConfigFile = function(configFilePath) {
 
 Jasmine.prototype.loadConfig = function(config) {
   var jasmineRunner = this;
-  jasmineRunner.specDir = config.spec_dir;
+  jasmineRunner.specDir = config.spec_dir || '';
 
   if(config.helpers) {
     config.helpers.forEach(function(helperFile) {

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -162,6 +162,26 @@ describe('Jasmine', function() {
 
         expect(this.fixtureJasmine.env.randomizeTests).toHaveBeenCalledWith(undefined);
       });
+
+      describe('with options', function() {
+        it('instantiates spec_dir with the provided value', function() {
+          this.fixtureJasmine.loadConfig(this.configObject);
+
+          expect(this.fixtureJasmine.specDir).toEqual('spec');
+        });
+      });
+
+      describe('without options', function() {
+        it('falls back to an empty string with an undefined spec_dir', function() {
+          var config = this.configObject;
+          delete config.spec_dir;
+
+          this.fixtureJasmine.loadConfig(config);
+
+          expect(this.fixtureJasmine.specDir).toEqual('');
+        });
+      });
+
     });
 
     describe('from a file', function() {


### PR DESCRIPTION
Motivation:
In full disclosure I am re-writing a plugin that I maintain [gulp-jasmine-phantom](https://github.com/dflynn15/gulp-jasmine-phantom) to use `jasmine-npm` instead of `minijasminenode` as it has become stale and does not include the full features that you all have worked so hard to make available to us. 

After playing with it I quickly realized that the `spec_dir` parameter was _required_ in the configuration in order to run `jasmine.execute()`. Adding this mandatory option felt unnecessary as you can provide full file paths, or even shortened ones, to Jasmine without it needing to know about your directory structure. Node's internal `path.resolve` and `path.join` will already handle the merge of any odd directory structures and does not need to understand how we place specs in directories.

Changes:
- This allows users to specify `spec_dir` if they want, but does not require them to do so
- Provides fallback of `''` to the jasmine runner when `spec_dir` is not provided

Validation:
- Modify `spec/support/jasmine.json` to be:
```json
{
  "spec_files": [
    "spec/command_spec.js",
    "spec/jasmine_spec.js",
    "spec/reporters/**/*[sS]pec.js",
    "spec/filters/**/*[sS]pec.js"
  ],
  "helpers": [
    "spec/helpers/**/*.js"
  ],
  "random": true
}
```
- Then run `npm test`

I realize that I may be imposing uninformed decisions on the module so I would love any critique and/or feedback. I am certain there was a reason why the `spec_dir` was determined to be mandatory so I would love to hear about that decision and why this PR may just simply be useless.

This would close #69 

@slackersoft @amavisca @wendorf 