### PR TITLE
Allow to run without jasmine.json #61

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -164,9 +164,10 @@ function help(options) {
   print('Options:');
   print('%s\tturn off color in spec output', lPad('--no-color', 18));
   print('%s\tfilter specs to run only those that match the given string', lPad('--filter=', 18));
-  print('%s\t[true|false] stop spec execution on expectation failure. This takes precedence over the stopSpecOnExpectationFailure option in jasmine.json', lPad('--stop-on-failure=', 18));
+  print('%s\t[true|false] stop spec execution on expectation failure', lPad('--stop-on-failure=', 18));
   print('');
-  print('The path to your jasmine.json can be configured by setting the JASMINE_CONFIG_PATH environment variable');
+  print('The given arguments take precedence over options in your jasmine.json');
+  print('The path to your optional jasmine.json can be configured by setting the JASMINE_CONFIG_PATH environment variable');
 }
 
 function version(options) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,6 +57,7 @@ function isFileArg(arg) {
 
 function parseOptions(argv) {
   var files = [],
+      helpers,
       color = process.stdout.isTTY || false,
       filter,
       stopOnFailure,
@@ -68,6 +69,8 @@ function parseOptions(argv) {
       color = false;
     } else if (arg.match("^--filter=")) {
       filter = arg.match("^--filter=(.*)")[1];
+    } else if (arg.match("^--helper=")) {
+      helpers = arg.match("^--helper=(.*)")[1].split(',');
     } else if (arg.match("^--stop-on-failure=")) {
       stopOnFailure = arg.match("^--stop-on-failure=(.*)")[1] === 'true';
     } else if (arg.match("^--random=")) {
@@ -82,6 +85,7 @@ function parseOptions(argv) {
     color: color,
     filter: filter,
     stopOnFailure: stopOnFailure,
+    helpers: helpers,
     files: files,
     random: random,
     seed: seed
@@ -98,6 +102,9 @@ function runJasmine(jasmine, env) {
   }
   if (env.random !== undefined) {
     jasmine.randomizeTests(env.random);
+  }
+  if (env.helpers !== undefined) {
+    jasmine.addHelperFiles(env.helpers, true);
   }
   jasmine.showColors(env.color);
   jasmine.execute(env.files, env.filter);
@@ -164,6 +171,7 @@ function help(options) {
   print('Options:');
   print('%s\tturn off color in spec output', lPad('--no-color', 18));
   print('%s\tfilter specs to run only those that match the given string', lPad('--filter=', 18));
+  print('%s\tload helper files that match the given string. Separate multiple patterns with ,', lPad('--helper=', 18));
   print('%s\t[true|false] stop spec execution on expectation failure', lPad('--stop-on-failure=', 18));
   print('');
   print('The given arguments take precedence over options in your jasmine.json');

--- a/lib/command.js
+++ b/lib/command.js
@@ -172,7 +172,7 @@ function help(options) {
 function version(options) {
   var print = options.print;
   print('jasmine v' + require('../package.json').version);
-  print('jasmine-core v' + require('../node_modules/jasmine-core/package.json').version);
+  print('jasmine-core v' + require('jasmine-core/package.json').version);
 }
 
 function lPad(str, length) {

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -79,9 +79,13 @@ Jasmine.prototype.loadHelpers = function() {
 };
 
 Jasmine.prototype.loadConfigFile = function(configFilePath) {
-  var absoluteConfigFilePath = path.resolve(this.projectBaseDir, configFilePath || 'spec/support/jasmine.json');
-  var config = require(absoluteConfigFilePath);
-  this.loadConfig(config);
+  try {
+    var absoluteConfigFilePath = path.resolve(this.projectBaseDir, configFilePath || 'spec/support/jasmine.json');
+    var config = require(absoluteConfigFilePath);
+    this.loadConfig(config);
+  } catch (e) {
+    if(configFilePath || e.code != 'MODULE_NOT_FOUND') { throw e; }
+  }
 };
 
 Jasmine.prototype.loadConfig = function(config) {

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -15,6 +15,7 @@ function Jasmine(options) {
   this.jasmine = jasmineCore.boot(jasmineCore);
   this.projectBaseDir = options.projectBaseDir || path.resolve();
   this.printDeprecation = options.printDeprecation || require('./printDeprecation');
+  this.specDir = '';
   this.specFiles = [];
   this.helperFiles = [];
   this.env = this.jasmine.getEnv();
@@ -89,40 +90,39 @@ Jasmine.prototype.loadConfigFile = function(configFilePath) {
 };
 
 Jasmine.prototype.loadConfig = function(config) {
-  var jasmineRunner = this;
-  jasmineRunner.specDir = config.spec_dir;
-
-  if(config.helpers) {
-    config.helpers.forEach(function(helperFile) {
-      var filePaths = glob.sync(path.join(jasmineRunner.projectBaseDir, jasmineRunner.specDir, helperFile));
-      filePaths.forEach(function(filePath) {
-        if(jasmineRunner.helperFiles.indexOf(filePath) === -1) {
-          jasmineRunner.helperFiles.push(filePath);
-        }
-      });
-    });
-  }
-
+  this.specDir = config.spec_dir || this.spec_dir;
   this.env.throwOnExpectationFailure(config.stopSpecOnExpectationFailure);
   this.env.randomizeTests(config.random);
 
+  if(config.helpers) {
+    this.addHelperFiles(config.helpers);
+  }
+
   if(config.spec_files) {
-    jasmineRunner.addSpecFiles(config.spec_files);
+    this.addSpecFiles(config.spec_files);
   }
 };
 
-Jasmine.prototype.addSpecFiles = function(files) {
-  var jasmineRunner = this;
+Jasmine.prototype.addHelperFiles = addFiles('helperFiles');
+Jasmine.prototype.addSpecFiles = addFiles('specFiles');
 
-  files.forEach(function(specFile) {
-    var filePaths = glob.sync(path.join(jasmineRunner.projectBaseDir, jasmineRunner.specDir, specFile));
-    filePaths.forEach(function(filePath) {
-      if(jasmineRunner.specFiles.indexOf(filePath) === -1) {
-        jasmineRunner.specFiles.push(filePath);
-      }
+function addFiles(kind) {
+  return function (files, replace) {
+    if(replace) { this[kind] = []; }
+
+    var jasmineRunner = this;
+    var fileArr = this[kind];
+
+    files.forEach(function(file) {
+      var filePaths = glob.sync(path.join(jasmineRunner.projectBaseDir, jasmineRunner.specDir, file));
+      filePaths.forEach(function(filePath) {
+        if(fileArr.indexOf(filePath) === -1) {
+          fileArr.push(filePath);
+        }
+      });
     });
-  });
-};
+  };
+}
 
 Jasmine.prototype.onComplete = function(onCompleteCallback) {
   this.exitCodeReporter.onComplete(onCompleteCallback);
@@ -151,8 +151,7 @@ Jasmine.prototype.execute = function(files, filterString) {
 
   if (files && files.length > 0) {
     this.specDir = '';
-    this.specFiles = [];
-    this.addSpecFiles(files);
+    this.addSpecFiles(files, true);
   }
 
   this.loadSpecs();


### PR DESCRIPTION
Here is my proposal for issue #61 (e973bcf)
The loading error is only suppressed  if no environment variable is set.

dcfcfa6 is a fix for the changes in npm 3 (node_modules are now mostly in the some dir).

4d64a13 has a bit of refactor to use the same code to glob for files. I hope thats ok ;-)