### PR TITLE
Enable regex filter by omitting automatic escaping

### DIFF
--- a/lib/filters/console_spec_filter.js
+++ b/lib/filters/console_spec_filter.js
@@ -1,7 +1,7 @@
 module.exports = exports = ConsoleSpecFilter;
 
 function ConsoleSpecFilter(options) {
-  var filterString = options && options.filterString && options.filterString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+  var filterString = options && options.filterString;
   var filterPattern = new RegExp(filterString);
 
   this.matches = function(specName) {


### PR DESCRIPTION
Currently there is no way for the user to filter (`--filter`) using a regex pattern. This is due to the current implementation automatically escaping the passed filter parameter. This tiny PR enables the user to filter using a regex pattern. It is better for the following reasons:
- Enables the user to decide whether to pass a regex pattern or a normal string (manual escape).
- Simplifies the implementation as there is no need to cover all possible special regex characters. But most importantly,
- Allows running specific modules/tests. For example:
```javascript
it('math', function() {
  ...
});
it('discrete math', function() {
  ...
});
describe('math equations', function() {
  ...
});
```
With the current implementation, `jasmine --filter='math'` will test all three, and `jasmine --filter='^math$'` will test nothing (auto escaped). However, with this PR,  `jasmine --filter='math'` will still test all three, but more importantly,  `jasmine --filter='^math$'` will now only run the top 'math' test (expected behaviour). You can still do things like `jasmine --filter='^math equations'` to run 'math equations' and its sub-tests. Also, the user can manually escape special regex characters if needed.