### PR TITLE
Add reporters support to jasmine.json config file

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -115,6 +115,13 @@ Jasmine.prototype.loadConfig = function(config) {
   if(config.spec_files) {
     jasmineRunner.addSpecFiles(config.spec_files);
   }
+
+  if(config.reporters && config.reporters.length > 0) {
+    config.reporters.forEach(function(reporter) {
+      var Reporter = require(reporter.name);
+      jasmineRunner.addReporter(new Reporter(reporter.options));
+    });
+  }
 };
 
 Jasmine.prototype.addSpecFiles = function(files) {


### PR DESCRIPTION
This way we can specify our reporters declaratively in the `spec/support/jasmine.json` config file without having to touch the runner execution.
Example:

``` json
{
  "reporters": [
    {
      "name": "jasmine-spec-reporter",
      "options": {
        "displayStacktrace": "all"
      }
    }
  ]
}
```
