### PR TITLE
Only use the default exiting if the default reporter is used

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -18,6 +18,7 @@ function Jasmine(options) {
   this.specFiles = [];
   this.helperFiles = [];
   this.env = this.jasmine.getEnv();
+  this.reportersCount = 0;
   this.exitCodeReporter = new ExitCodeReporter();
   this.onCompleteCallbackAdded = false;
   this.exit = exit;
@@ -46,6 +47,7 @@ Jasmine.prototype.addSpecFile = function(filePath) {
 
 Jasmine.prototype.addReporter = function(reporter) {
   this.env.addReporter(reporter);
+  this.reportersCount++;
 };
 
 Jasmine.prototype.provideFallbackReporter = function(reporter) {
@@ -65,7 +67,7 @@ Jasmine.prototype.configureDefaultReporter = function(options) {
   }
   var consoleReporter = new module.exports.ConsoleReporter(options);
   this.provideFallbackReporter(consoleReporter);
-  this.defaultReporterAdded = true;
+  this.defaultReporterAdded = this.reportersCount === 0 ? true : false;
 };
 
 Jasmine.prototype.addMatchers = function(matchers) {

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -67,7 +67,7 @@ Jasmine.prototype.configureDefaultReporter = function(options) {
   }
   var consoleReporter = new module.exports.ConsoleReporter(options);
   this.provideFallbackReporter(consoleReporter);
-  this.defaultReporterAdded = this.reportersCount === 0 ? true : false;
+  this.defaultReporterAdded = this.reportersCount === 0;
 };
 
 Jasmine.prototype.addMatchers = function(matchers) {

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -85,12 +85,24 @@ describe('Jasmine', function() {
       expect(this.testJasmine.env.provideFallbackReporter).toHaveBeenCalledWith({someProperty: 'some value'});
     });
 
-    it('sets the defaultReporterAdded flag', function() {
-      var reporterOptions = {};
+    describe('sets the defaultReportedAdded flag', function() {
+      it('to true if the default reporter is used', function() {
+        var reporterOptions = {};
 
-      this.testJasmine.configureDefaultReporter(reporterOptions);
+        this.testJasmine.configureDefaultReporter(reporterOptions);
 
-      expect(this.testJasmine.defaultReporterAdded).toBe(true);
+        expect(this.testJasmine.defaultReporterAdded).toBe(true);
+      });
+
+      it('to false if the default reporter is not used', function() {
+        var reporterOptions = {};
+        var dummyReporter = {};
+
+        this.testJasmine.addReporter(dummyReporter);
+        this.testJasmine.configureDefaultReporter(reporterOptions);
+
+        expect(this.testJasmine.defaultReporterAdded).toBe(false);
+      });
     });
 
     describe('passing in an onComplete function', function() {


### PR DESCRIPTION
Fixes #88.