### PR TITLE
Fix setOptions to the ConsoleReporter if it exists on the options param

### DIFF
--- a/lib/reporters/console_reporter.js
+++ b/lib/reporters/console_reporter.js
@@ -27,17 +27,27 @@ function ConsoleReporter() {
     onComplete = function() {};
 
   this.setOptions = function(options) {
-    print = options.print;
+    if (options.print) {
+      print = options.print;
+    }
     showColors = options.showColors || false;
-    timer = options.timer || noopTimer;
-    jasmineCorePath = options.jasmineCorePath;
-    printDeprecation = options.printDeprecation || require('../printDeprecation');
-    stackFilter = options.stackFilter || defaultStackFilter;
+    if (options.timer) {
+      timer = options.timer;
+    }
+    if (options.jasmineCorePath) {
+      jasmineCorePath = options.jasmineCorePath;
+    }
+    if (options.printDeprecation) {
+      printDeprecation = options.printDeprecation;
+    }
+    if (options.stackFilter) {
+      stackFilter = options.stackFilter;
+    }
 
     if(options.onComplete) {
       printDeprecation('Passing in an onComplete function to the ConsoleReporter is deprecated.');
+      onComplete = options.onComplete;
     }
-    onComplete = options.onComplete || function() {};
   };
 
   this.jasmineStarted = function() {

--- a/spec/reporters/console_reporter_spec.js
+++ b/spec/reporters/console_reporter_spec.js
@@ -51,6 +51,34 @@ describe("ConsoleReporter", function() {
     expect(this.out.getOutput()).toEqual("Started\n");
   });
 
+  it("setOptions should not override existing options if set multiple times", function() {
+    var timerSpy = jasmine.createSpyObj('timer', ['start']),
+        reporter = new ConsoleReporter();
+
+    reporter.setOptions({
+      print: this.out.print,
+      timer: timerSpy
+    });
+
+    reporter.jasmineStarted();
+    expect(timerSpy.start).toHaveBeenCalled();
+    expect(this.out.getOutput()).toEqual("Started\n");
+
+    // clean up this.out.output
+    this.out.clear();
+    expect(this.out.getOutput()).toEqual("");
+
+    // set options that does not include print, should still print with this.out.print
+    reporter.setOptions({
+      timer: timerSpy
+    });
+
+    reporter.jasmineStarted();
+    expect(timerSpy.start).toHaveBeenCalled();
+    expect(this.out.getOutput()).toEqual("Started\n");
+  });
+
+
   it("starts the provided timer when jasmine starts", function() {
     var timerSpy = jasmine.createSpyObj('timer', ['start']),
         reporter = new ConsoleReporter();


### PR DESCRIPTION
- move default values for setOptions to the var when defined
- setOptions to the ConsoleReporter if it exists on the options param
- test setOptions should not override existing options if set multiple times

closes #95
