### PR TITLE
Don't call configureDefaultReporter in execute if it was already called.

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -26,6 +26,7 @@ function Jasmine(options) {
   this.showingColors = true;
   this.reporter = new module.exports.ConsoleReporter();
   this.env.addReporter(this.reporter);
+  this.defaultReporterConfigured = false;
 
   var jasmineRunner = this;
   this.completionReporter.onComplete(function(passed) {
@@ -74,6 +75,7 @@ Jasmine.prototype.configureDefaultReporter = function(options) {
     this.printDeprecation('Passing in an onComplete function to configureDefaultReporter is deprecated.');
   }
   this.reporter.setOptions(options);
+  this.defaultReporterConfigured = true;
 };
 
 Jasmine.prototype.addMatchers = function(matchers) {
@@ -157,7 +159,9 @@ Jasmine.prototype.exitCodeCompletion = function(passed) {
 
 Jasmine.prototype.execute = function(files, filterString) {
   this.loadHelpers();
-  this.configureDefaultReporter({ showColors: this.showingColors });
+  if (!this.defaultReporterConfigured) {
+    this.configureDefaultReporter({ showColors: this.showingColors });
+  }
 
   if(filterString) {
     var specFilter = new ConsoleSpecFilter({

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -320,6 +320,20 @@ describe('Jasmine', function() {
       expect(this.testJasmine.env.execute).toHaveBeenCalled();
     });
 
+    it('does not configure the default reporter if this was already done', function() {
+      spyOn(this.testJasmine, 'loadSpecs');
+
+      this.testJasmine.configureDefaultReporter({showColors: false});
+
+      spyOn(this.testJasmine, 'configureDefaultReporter');
+
+      this.testJasmine.execute();
+
+      expect(this.testJasmine.configureDefaultReporter).not.toHaveBeenCalled();
+      expect(this.testJasmine.loadSpecs).toHaveBeenCalled();
+      expect(this.testJasmine.env.execute).toHaveBeenCalled();
+    });
+
     it('loads helper files before checking if any reporters were added', function() {
       var loadHelpers = spyOn(this.testJasmine, 'loadHelpers');
       spyOn(this.testJasmine, 'configureDefaultReporter').and.callFake(function() {


### PR DESCRIPTION
This is the naïve fix for https://github.com/jasmine/jasmine-npm/issues/95 as it appears @cnishina is working on a different but related problem.