### PR TITLE
Allows a customizable spec loader

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -2,6 +2,7 @@ var path = require('path'),
     util = require('util'),
     glob = require('glob'),
     exit = require('./exit'),
+    whenAll = require('./whenAll'),
     CompletionReporter = require('./reporters/completion_reporter'),
     ConsoleSpecFilter = require('./filters/console_spec_filter');
 
@@ -25,6 +26,7 @@ function Jasmine(options) {
   this.exit = exit;
   this.showingColors = true;
   this.reporter = new module.exports.ConsoleReporter();
+  this.fileLoader = options.fileLoader || require;
   this.env.addReporter(this.reporter);
   this.defaultReporterConfigured = false;
 
@@ -82,16 +84,12 @@ Jasmine.prototype.addMatchers = function(matchers) {
   this.jasmine.Expectation.addMatchers(matchers);
 };
 
-Jasmine.prototype.loadSpecs = function() {
-  this.specFiles.forEach(function(file) {
-    require(file);
-  });
+Jasmine.prototype.loadSpecs = function(done) {
+  whenAll(this.specFiles, this.fileLoader, done);
 };
 
-Jasmine.prototype.loadHelpers = function() {
-  this.helperFiles.forEach(function(file) {
-    require(file);
-  });
+Jasmine.prototype.loadHelpers = function(done) {
+  whenAll(this.helperFiles, this.fileLoader, done);
 };
 
 Jasmine.prototype.loadConfigFile = function(configFilePath) {
@@ -158,28 +156,56 @@ Jasmine.prototype.exitCodeCompletion = function(passed) {
 };
 
 Jasmine.prototype.execute = function(files, filterString) {
-  this.loadHelpers();
-  if (!this.defaultReporterConfigured) {
-    this.configureDefaultReporter({ showColors: this.showingColors });
-  }
+  var jasmineRunner = this;
+  var deferred = new Deferred();
 
-  if(filterString) {
-    var specFilter = new ConsoleSpecFilter({
-      filterString: filterString
+  this.loadHelpers(function() {
+    if (!jasmineRunner.defaultReporterConfigured) {
+      jasmineRunner.configureDefaultReporter({ showColors: jasmineRunner.showingColors });
+    }
+    
+    if (filterString) {
+      var specFilter = new ConsoleSpecFilter({
+        filterString: filterString
+      });
+      jasmineRunner.env.specFilter = function (spec) {
+        return specFilter.matches(spec.getFullName());
+      };
+    }
+
+    if (files && files.length > 0) {
+      jasmineRunner.specDir = '';
+      jasmineRunner.specFiles = [];
+      jasmineRunner.addSpecFiles(files);
+    }
+
+    jasmineRunner.addReporter(jasmineRunner.completionReporter);
+
+    jasmineRunner.loadSpecs(function() {
+      jasmineRunner.env.execute();
+      deferred.resolve();
     });
-    this.env.specFilter = function(spec) {
-      return specFilter.matches(spec.getFullName());
-    };
+  });
+
+  return deferred;
+};
+
+var Deferred = function(){
+  this.isResolved = false;
+};
+
+Deferred.prototype.resolve = function() {
+  this.isResolved = true;
+  this.executeCallbackIfResolved();
+};
+
+Deferred.prototype.executeCallbackIfResolved = function(){
+  if(this.isResolved && typeof this.callback === 'function') {
+    this.callback.call(null);
   }
+};
 
-  if (files && files.length > 0) {
-    this.specDir = '';
-    this.specFiles = [];
-    this.addSpecFiles(files);
-  }
-
-  this.loadSpecs();
-
-  this.addReporter(this.completionReporter);
-  this.env.execute();
+Deferred.prototype.done = function(callback) {
+  this.callback = callback;
+  this.executeCallbackIfResolved();
 };

--- a/lib/whenAll.js
+++ b/lib/whenAll.js
@@ -1,0 +1,36 @@
+function whenAll(items, handler, done){
+  var queueLength = items.length;
+  if(queueLength === 0) {
+    done();
+    return;
+  }
+
+  var completed = 0;
+  
+  var queueableFnDone = function(){
+    if(++completed  >= queueLength){
+      done();
+    }
+  };
+
+  if(handler.length > 1){
+    items.forEach(function(item) {
+      attempAsync(item, handler, queueableFnDone);
+    }, this);
+  } else  {
+    items.forEach(function(item) {
+      attempSync(item, handler, queueableFnDone);
+    }, this);
+  }
+}
+
+function attempAsync(argument, handler, queueableFnDone) {
+    handler.call(null, argument, queueableFnDone);
+}
+
+function attempSync(argument, handler, queueableFnDone) {
+    handler.call(null, argument);
+    queueableFnDone();
+}
+
+module.exports = whenAll;

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -297,85 +297,122 @@ describe('Jasmine', function() {
   });
 
   describe('#execute', function() {
-    it('uses the default console reporter if no reporters were added', function() {
+    it('uses the default console reporter if no reporters were added', function(done) {
       spyOn(this.testJasmine, 'configureDefaultReporter');
-      spyOn(this.testJasmine, 'loadSpecs');
+      spyOn(this.testJasmine, 'loadSpecs').and.callFake(function(done) {
+        done();
+      });
 
-      this.testJasmine.execute();
+      var _this = this;
+      this.testJasmine.execute().done(function() {
 
-      expect(this.testJasmine.configureDefaultReporter).toHaveBeenCalledWith({showColors: true});
-      expect(this.testJasmine.loadSpecs).toHaveBeenCalled();
-      expect(this.testJasmine.env.execute).toHaveBeenCalled();
+        expect(_this.testJasmine.configureDefaultReporter).toHaveBeenCalledWith({showColors: true});
+        expect(_this.testJasmine.loadSpecs).toHaveBeenCalled();
+        expect(_this.testJasmine.env.execute).toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('configures the default console reporter with the right color settings', function() {
+    it('configures the default console reporter with the right color settings', function(done) {
       spyOn(this.testJasmine, 'configureDefaultReporter');
-      spyOn(this.testJasmine, 'loadSpecs');
+      spyOn(this.testJasmine, 'loadSpecs').and.callFake(function(done) {
+        done();
+      });
+
       this.testJasmine.showColors(false);
 
-      this.testJasmine.execute();
+      var _this = this;
+      this.testJasmine.execute().done(function() {
 
-      expect(this.testJasmine.configureDefaultReporter).toHaveBeenCalledWith({showColors: false});
-      expect(this.testJasmine.loadSpecs).toHaveBeenCalled();
-      expect(this.testJasmine.env.execute).toHaveBeenCalled();
+        expect(_this.testJasmine.configureDefaultReporter).toHaveBeenCalledWith({showColors: false});
+        expect(_this.testJasmine.loadSpecs).toHaveBeenCalled();
+        expect(_this.testJasmine.env.execute).toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('does not configure the default reporter if this was already done', function() {
-      spyOn(this.testJasmine, 'loadSpecs');
+    it('does not configure the default reporter if this was already done', function(done) {
+      spyOn(this.testJasmine, 'loadSpecs').and.callFake(function(done) {
+        done();
+      });
 
       this.testJasmine.configureDefaultReporter({showColors: false});
 
       spyOn(this.testJasmine, 'configureDefaultReporter');
 
-      this.testJasmine.execute();
+      var _this = this;
+      this.testJasmine.execute().done(function() {
 
-      expect(this.testJasmine.configureDefaultReporter).not.toHaveBeenCalled();
-      expect(this.testJasmine.loadSpecs).toHaveBeenCalled();
-      expect(this.testJasmine.env.execute).toHaveBeenCalled();
+        expect(_this.testJasmine.configureDefaultReporter).not.toHaveBeenCalled();
+        expect(_this.testJasmine.loadSpecs).toHaveBeenCalled();
+        expect(_this.testJasmine.env.execute).toHaveBeenCalled();
+        done();
+      });  
     });
 
-    it('loads helper files before checking if any reporters were added', function() {
-      var loadHelpers = spyOn(this.testJasmine, 'loadHelpers');
+    it('loads helper files before checking if any reporters were added', function(done) {
+      var loadHelpers = spyOn(this.testJasmine, 'loadHelpers').and.callFake(function(done) {
+        done();
+      });
+
       spyOn(this.testJasmine, 'configureDefaultReporter').and.callFake(function() {
         expect(loadHelpers).toHaveBeenCalled();
       });
-      spyOn(this.testJasmine, 'loadSpecs');
-
-      this.testJasmine.execute();
-
-      expect(this.testJasmine.configureDefaultReporter).toHaveBeenCalled();
-    });
-
-    it('can run only specified files', function() {
-      spyOn(this.testJasmine, 'configureDefaultReporter');
-      spyOn(this.testJasmine, 'loadSpecs');
-
-      this.testJasmine.loadConfigFile();
-
-      this.testJasmine.execute(['spec/fixtures/**/*spec.js']);
-
-      var relativePaths = this.testJasmine.specFiles.map(function(path) {
-        return path.replace(__dirname, '');
+      spyOn(this.testJasmine, 'loadSpecs').and.callFake(function(done) {
+        done();
       });
 
-      expect(relativePaths).toEqual(['/fixtures/sample_project/spec/fixture_spec.js', '/fixtures/sample_project/spec/other_fixture_spec.js']);
+      var _this = this;
+      this.testJasmine.execute().done(function() {
+
+        expect(_this.testJasmine.configureDefaultReporter).toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('should add spec filter if filterString is provided', function() {
+    it('can run only specified files', function(done) {
+      spyOn(this.testJasmine, 'configureDefaultReporter');
+      spyOn(this.testJasmine, 'loadSpecs').and.callFake(function(done) {
+        done();
+      });
+
       this.testJasmine.loadConfigFile();
 
-      this.testJasmine.execute(['spec/fixtures/**/*spec.js'], 'interesting spec');
-      expect(this.testJasmine.env.specFilter).toEqual(jasmine.any(Function));
+      var _this = this;
+      this.testJasmine.execute(['spec/fixtures/**/*spec.js']).done(function() {
+
+        var relativePaths = _this.testJasmine.specFiles.map(function(path) {
+          return path.replace(__dirname, '');
+        });
+
+        expect(relativePaths).toEqual(['/fixtures/sample_project/spec/fixture_spec.js', '/fixtures/sample_project/spec/other_fixture_spec.js']);
+        done();
+      });
+
     });
 
-    it('adds an exit code reporter', function() {
+    it('should add spec filter if filterString is provided', function(done) {
+      this.testJasmine.loadConfigFile();
+
+      var _this = this;
+      this.testJasmine.execute(['spec/fixtures/**/*spec.js'], 'interesting spec').done(function() {
+
+        expect(_this.testJasmine.env.specFilter).toEqual(jasmine.any(Function));
+        done();
+      });
+    });
+
+    it('adds an exit code reporter', function(done) {
       var completionReporterSpy = jasmine.createSpyObj('reporter', ['onComplete']);
       this.testJasmine.completionReporter = completionReporterSpy;
       spyOn(this.testJasmine, 'addReporter');
 
-      this.testJasmine.execute();
+      var _this = this;
+      this.testJasmine.execute().done(function() {
 
-      expect(this.testJasmine.addReporter).toHaveBeenCalledWith(completionReporterSpy);
+        expect(_this.testJasmine.addReporter).toHaveBeenCalledWith(completionReporterSpy);
+        done();
+      });
     });
 
     describe('default completion behavior', function() {


### PR DESCRIPTION
I've been trying to get Jasmine working with modules for SystemJs.
Our build compiles the typescript with the `system` module resolution and then we need to get the unit tests (also TS) executed. We tend to avoid using the phantomjs or run it in a web browser to minimize build times. I'd like to introduce a way to configure how the spec files should be loaded, eg. implementation with systemJs:
```
new Jasmine({
  fileLoader: (file, done) => {
   system.import(`file:///${file}`).then(done);
  }
})
```