### PR TITLE
Fix #85 - Option to specify path to your jasmine.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Customize `spec/support/jasmine.json` to enumerate the source and spec files you
 You may use dir glob strings.
 More information on the format of `jasmine.json` can be found in [the documentation](http://jasmine.github.io/2.4/node.html#section-Configuration)
 
-Alternatively, you may specify the path to your `jasmine.json` by setting an environment variable:
+Alternatively, you may specify the path to your `jasmine.json` by setting an environment variable or an option:
 
 `jasmine JASMINE_CONFIG_PATH=relative/path/to/your/jasmine.json`
+`jasmine --config=relative/path/to/your/jasmine.json`
 
 ## Support
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -59,6 +59,7 @@ function parseOptions(argv) {
   var files = [],
       helpers = [],
       color = process.stdout.isTTY || false,
+      configPath,
       filter,
       stopOnFailure,
       random,
@@ -77,12 +78,15 @@ function parseOptions(argv) {
       random = arg.match("^--random=(.*)")[1] === 'true';
     } else if (arg.match("^--seed=")) {
       seed = arg.match("^--seed=(.*)")[1];
+    } else if (arg.match("^--config=")) {
+      configPath = arg.match("^--config=(.*)")[1];
     } else if (isFileArg(arg)) {
       files.push(arg);
     }
   });
   return {
     color: color,
+    configPath: configPath,
     filter: filter,
     stopOnFailure: stopOnFailure,
     helpers: helpers,
@@ -93,7 +97,7 @@ function parseOptions(argv) {
 }
 
 function runJasmine(jasmine, env) {
-  jasmine.loadConfigFile(process.env.JASMINE_CONFIG_PATH);
+  jasmine.loadConfigFile(env.configPath || process.env.JASMINE_CONFIG_PATH);
   if (env.stopOnFailure !== undefined) {
     jasmine.stopSpecOnExpectationFailure(env.stopOnFailure);
   }
@@ -173,9 +177,10 @@ function help(options) {
   print('%s\tfilter specs to run only those that match the given string', lPad('--filter=', 18));
   print('%s\tload helper files that match the given string', lPad('--helper=', 18));
   print('%s\t[true|false] stop spec execution on expectation failure', lPad('--stop-on-failure=', 18));
+  print('%s\tpath to your optional jasmine.json', lPad('--config=', 18));
   print('');
   print('The given arguments take precedence over options in your jasmine.json');
-  print('The path to your optional jasmine.json can be configured by setting the JASMINE_CONFIG_PATH environment variable');
+  print('The path to your optional jasmine.json can also be configured by setting the JASMINE_CONFIG_PATH environment variable');
 }
 
 function version(options) {

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -158,8 +158,13 @@ describe('command', function() {
       expect(this.fakeJasmine.loadConfigFile).toHaveBeenCalledWith(undefined);
     });
 
-    it('should load a custom config file', function() {
+    it('should load a custom config file specified by env variable', function() {
       this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', 'JASMINE_CONFIG_PATH=somewhere.json']);
+      expect(this.fakeJasmine.loadConfigFile).toHaveBeenCalledWith('somewhere.json');
+    });
+
+    it('should load a custom config file specified by option', function() {
+      this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--config=somewhere.json']);
       expect(this.fakeJasmine.loadConfigFile).toHaveBeenCalledWith('somewhere.json');
     });
 


### PR DESCRIPTION
Usage:
`--config=	path to your optional jasmine.json`