### PR TITLE
Fix #53 - Reject unknown options

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -46,7 +46,14 @@ function Command(projectBaseDir, examplesDir, print) {
     if (commandToRun) {
       commandToRun.action({jasmine: jasmine, projectBaseDir: command.projectBaseDir, specDir: command.specDir, examplesDir: examplesDir, print: print});
     } else {
-      runJasmine(jasmine, parseOptions(commands));
+      var env = parseOptions(commands);
+      if (env.unknownOptions.length > 0) {
+        print('Unknown options: ' + env.unknownOptions.join(', '));
+        print('');
+        help({print: print});
+      } else {
+        runJasmine(jasmine, env);
+      }
     }
   };
 }
@@ -58,6 +65,7 @@ function isFileArg(arg) {
 function parseOptions(argv) {
   var files = [],
       helpers = [],
+      unknownOptions = [],
       color = process.stdout.isTTY || false,
       filter,
       stopOnFailure,
@@ -79,6 +87,8 @@ function parseOptions(argv) {
       seed = arg.match("^--seed=(.*)")[1];
     } else if (isFileArg(arg)) {
       files.push(arg);
+    } else if (!isEnvironmentVariable(arg)) {
+      unknownOptions.push(arg);
     }
   });
   return {
@@ -88,7 +98,8 @@ function parseOptions(argv) {
     helpers: helpers,
     files: files,
     random: random,
-    seed: seed
+    seed: seed,
+    unknownOptions: unknownOptions
   };
 }
 

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -111,6 +111,14 @@ describe('command', function() {
     });
   });
 
+  describe('passing unknown options', function() {
+    it('display unknown options and usage', function() {
+      this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--some-option', '--no-color', '--another-option']);
+      expect(this.out.getOutput()).toContain('Unknown options: --some-option, --another-option');
+      expect(this.out.getOutput()).toContain('Usage');
+    });
+  });
+
   describe('examples', function() {
     beforeEach(function() {
       this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', 'examples']);
@@ -188,7 +196,7 @@ describe('command', function() {
     });
 
     it('should be able to run only specified specs', function() {
-      this.command.run(this.fakeJasmine, ['spec/some/fileSpec.js', 'SOME_ENV=SOME_VALUE', '--some-option']);
+      this.command.run(this.fakeJasmine, ['spec/some/fileSpec.js', 'SOME_ENV=SOME_VALUE', '--no-color']);
       expect(this.fakeJasmine.execute).toHaveBeenCalledWith(['spec/some/fileSpec.js'], undefined);
     });
 


### PR DESCRIPTION
```sh
$ jasmine --some-option --another-option
Unknown options: --some-option, --another-option

Usage: jasmine [command] [options] [files]

Commands:
...
```