### PR TITLE
set default for random option

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -102,6 +102,8 @@ function runJasmine(jasmine, env) {
   }
   if (env.random !== undefined) {
     jasmine.randomizeTests(env.random);
+  } else {
+    jasmine.randomizeTests(false); 
   }
   if (env.helpers !== undefined && env.helpers.length) {
     jasmine.addHelperFiles(env.helpers);


### PR DESCRIPTION
This prevents it from remaining `undefined` when not explicitly set in cli or config file.