### PR TITLE
Expose `closeReporters` methods in the wrapper

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -25,7 +25,7 @@ function Jasmine(options) {
   this.exit = exit;
   this.showingColors = true;
   this.reporter = new module.exports.ConsoleReporter();
-  this.env.addReporter(this.reporter);
+  this.addReporter(this.reporter);
   this.defaultReporterConfigured = false;
 
   var jasmineRunner = this;
@@ -58,6 +58,11 @@ Jasmine.prototype.addSpecFile = function(filePath) {
 Jasmine.prototype.addReporter = function(reporter) {
   this.env.addReporter(reporter);
   this.reportersCount++;
+};
+
+Jasmine.prototype.clearReporters = function() {
+  this.env.clearReporters();
+  this.reportersCount = 0;
 };
 
 Jasmine.prototype.provideFallbackReporter = function(reporter) {

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -7,6 +7,7 @@ describe('Jasmine', function() {
     this.bootedJasmine = {
       getEnv: jasmine.createSpy('getEnv').and.returnValue({
         addReporter: jasmine.createSpy('addReporter'),
+        clearReporters: jasmine.createSpy('clearReporters'),
         provideFallbackReporter: jasmine.createSpy('provideFallbackReporter'),
         execute: jasmine.createSpy('execute'),
         throwOnExpectationFailure: jasmine.createSpy('throwOnExpectationFailure'),
@@ -90,6 +91,17 @@ describe('Jasmine', function() {
 
     expect(testJasmine.env.addReporter).toHaveBeenCalledWith({someProperty: 'some value'});
   });
+
+  it('exposes #addReporter and #clearReporters', function() {
+    var testJasmine = new Jasmine({ jasmineCore: this.fakeJasmineCore });
+    expect(testJasmine.reportersCount).toEqual(1);
+    testJasmine.clearReporters()
+    expect(testJasmine.reportersCount).toEqual(0);
+    expect(testJasmine.env.clearReporters).toHaveBeenCalled();
+    testJasmine.addReporter({someProperty: 'some value'})
+    expect(testJasmine.reportersCount).toEqual(1);
+    expect(testJasmine.env.addReporter).toHaveBeenCalledWith({someProperty: 'some value'});
+  })
 
   describe('#configureDefaultReporter', function() {
     beforeEach(function() {

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -95,13 +95,13 @@ describe('Jasmine', function() {
   it('exposes #addReporter and #clearReporters', function() {
     var testJasmine = new Jasmine({ jasmineCore: this.fakeJasmineCore });
     expect(testJasmine.reportersCount).toEqual(1);
-    testJasmine.clearReporters()
+    testJasmine.clearReporters();
     expect(testJasmine.reportersCount).toEqual(0);
     expect(testJasmine.env.clearReporters).toHaveBeenCalled();
-    testJasmine.addReporter({someProperty: 'some value'})
+    testJasmine.addReporter({someProperty: 'some value'});
     expect(testJasmine.reportersCount).toEqual(1);
     expect(testJasmine.env.addReporter).toHaveBeenCalledWith({someProperty: 'some value'});
-  })
+  });
 
   describe('#configureDefaultReporter', function() {
     beforeEach(function() {


### PR DESCRIPTION
- Call correct `addReporter` in constructor to keep track of
  `reportersCount`
- Expose `closeReporters` from `env` and keep track of `reportersCount`
- Fixes jasmine/jasmine#1228