### PR TITLE
Delegate exit processing to CompletionReporter.

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -26,12 +26,6 @@ function Jasmine(options) {
   this.addReporter(this.reporter);
   this.defaultReporterConfigured = false;
 
-  var jasmineRunner = this;
-  this.completionReporter.onComplete(function(passed) {
-    jasmineRunner.exitCodeCompletion(passed);
-  });
-  this.checkExit = checkExit(this);
-
   this.coreVersion = function() {
     return jasmineCore.version();
   };
@@ -181,7 +175,6 @@ var checkExit = function(jasmineRunner) {
 };
 
 Jasmine.prototype.execute = function(files, filterString) {
-  process.on('exit', this.checkExit);
 
   this.loadHelpers();
   if (!this.defaultReporterConfigured) {

--- a/lib/reporters/completion_reporter.js
+++ b/lib/reporters/completion_reporter.js
@@ -1,17 +1,58 @@
+var exit = require('exit');
+
 module.exports = function() {
+  var results = true;
   var onCompleteCallback = function() {};
   var completed = false;
+  this.exit = exit;
 
   this.onComplete = function(callback) {
     onCompleteCallback = callback;
   };
 
+  this.jasmineStarted = function() {
+    if (!onCompleteCallback) {
+      onCompleteCallback = this.defaultOnCompleteCallback;
+    }
+    process.on('exit', this.exitHandler);
+  };
+
   this.jasmineDone = function(result) {
     completed = true;
+    process.removeListener('exit', this.exitHandler);
     onCompleteCallback(result.overallStatus === 'passed');
   };
 
   this.isComplete = function() {
     return completed;
   };
+
+  this.specDone = function(result) {
+    if(result.status === 'failed') {
+      results = false;
+    }
+  };
+
+  this.suiteDone = function(result) {
+    if (result.failedExpectations && result.failedExpectations.length > 0) {
+      results = false;
+    }
+  };
+
+  var reporter = this;
+  this.defaultOnCompleteCallback = function(passed) {
+    if(passed) {
+      reporter.exit(0, process.platform, process.version, process.exit, require('exit'));
+    }
+    else {
+      reporter.exit(1, process.platform, process.version, process.exit, require('exit'));
+    }
+  };
+
+  this.exitHandler = function() {
+    if (!this.isComplete()) {
+      process.exitCode = 4;
+    }
+  };
+
 };

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -401,47 +401,5 @@ describe('Jasmine', function() {
 
       expect(this.testJasmine.addReporter).toHaveBeenCalledWith(completionReporterSpy);
     });
-
-    describe('when exit is called prematurely', function() {
-      beforeEach(function() {
-        this.originalCode = process.exitCode;
-      });
-
-      afterEach(function() {
-        process.exitCode = this.originalCode;
-      });
-
-      it('sets the exit code to failure', function() {
-        this.testJasmine.checkExit();
-        expect(process.exitCode).toEqual(4);
-      });
-
-      it('leaves it if the suite has completed', function() {
-        var completionReporterSpy = jasmine.createSpyObj('reporter', ['isComplete']);
-        completionReporterSpy.isComplete.and.returnValue(true);
-        this.testJasmine.completionReporter = completionReporterSpy;
-
-        this.testJasmine.checkExit();
-        expect(process.exitCode).toBeUndefined();
-      });
-    });
-
-    describe('default completion behavior', function() {
-      it('exits successfully when the whole suite is green', function() {
-        var exitSpy = jasmine.createSpy('exit');
-        this.testJasmine.exit = exitSpy;
-
-        this.testJasmine.exitCodeCompletion(true);
-        expect(exitSpy).toHaveBeenCalledWith(0);
-      });
-
-      it('exits with a failure when anything in the suite is not green', function() {
-        var exitSpy = jasmine.createSpy('exit');
-        this.testJasmine.exit = exitSpy;
-
-        this.testJasmine.exitCodeCompletion(false);
-        expect(exitSpy).toHaveBeenCalledWith(1);
-      });
-    });
   });
 });

--- a/spec/reporters/completion_reporter_spec.js
+++ b/spec/reporters/completion_reporter_spec.js
@@ -20,4 +20,56 @@ describe('CompletionReporter', function() {
       expect(this.onComplete).toHaveBeenCalledWith(false);
     });
   });
+
+  describe('when exit is called prematurely', function() {
+    beforeEach(function() {
+      this.originalCode = process.exitCode;
+    });
+
+    afterEach(function() {
+      process.exitCode = this.originalCode;
+    });
+
+    it('sets the exit code to failure', function() {
+      this.reporter.exitHandler();
+      expect(process.exitCode).toEqual(4);
+    });
+
+    it('leaves it unset if the suite has completed', function() {
+      this.reporter.jasmineDone({overallStatus: 'passed'});
+      this.reporter.exitHandler();
+      expect(process.exitCode).toBeUndefined();
+    });
+  });
+
+  describe('default completion behavior', function() {
+    it('exits successfully when the whole suite is green', function() {
+      var exitSpy = jasmine.createSpy('exit');
+      this.reporter.exit = exitSpy;
+
+      this.reporter.defaultOnCompleteCallback(true);
+      expect(exitSpy).toHaveBeenCalledWith(0, process.platform, process.version, process.exit, require('exit'));
+    });
+
+    it('exits with a failure when anything in the suite is not green', function() {
+      var exitSpy = jasmine.createSpy('exit');
+      this.reporter.exit = exitSpy;
+
+      this.reporter.defaultOnCompleteCallback(false);
+      expect(exitSpy).toHaveBeenCalledWith(1, process.platform, process.version, process.exit, require('exit'));
+    });
+  });
+
+  describe('process exit listeners', function() {
+    it('adds and removes a process exit listener', function() {
+      var onSpy = spyOn(process, 'on').and.callThrough();
+      var removeListenerSpy = spyOn(process, 'removeListener').and.callThrough();
+
+      this.reporter.jasmineStarted();
+      this.reporter.jasmineDone({overallStatus: 'passed'});
+      expect(onSpy).toHaveBeenCalledWith('exit', this.reporter.exitHandler);
+      expect(removeListenerSpy).toHaveBeenCalledWith('exit', this.reporter.exitHandler);
+    });
+  });
+
 });


### PR DESCRIPTION
To ensure that the process on 'exit' listener is cleanly removed if and only
if the tests complete, we need to call removeListener in a jasmineDone() callback.
The CompletionReporter is the natural place to make the removal; then it makes
sense to attach the exit handler in a jasmineStarted() callback.

Further, to cleanly encapsulate exit handling, move the exit() calls to the
CompletionReporter. That simplifies the logic of exit handling as of jasmine main.