### PR TITLE
Add --force-color option

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -210,6 +210,7 @@ function help(options) {
 
   print('Options:');
   print('%s\tturn off color in spec output', lPad('--no-color', 18));
+  print('%s\tforce turn on color in spec output', lPad('--force-color', 18));
   print('%s\tfilter specs to run only those that match the given string', lPad('--filter=', 18));
   print('%s\tload helper files that match the given string', lPad('--helper=', 18));
   print('%s\t[true|false] stop spec execution on expectation failure', lPad('--stop-on-failure=', 18));

--- a/lib/command.js
+++ b/lib/command.js
@@ -78,7 +78,7 @@ function parseOptions(argv) {
   argv.forEach(function(arg) {
     if (arg === '--no-color') {
       color = false;
-    } else if (arg === '--force-color') {
+    } else if (arg === '--color') {
       color = true;
     } else if (arg.match("^--filter=")) {
       filter = arg.match("^--filter=(.*)")[1];
@@ -210,7 +210,7 @@ function help(options) {
 
   print('Options:');
   print('%s\tturn off color in spec output', lPad('--no-color', 18));
-  print('%s\tforce turn on color in spec output', lPad('--force-color', 18));
+  print('%s\tforce turn on color in spec output', lPad('--color', 18));
   print('%s\tfilter specs to run only those that match the given string', lPad('--filter=', 18));
   print('%s\tload helper files that match the given string', lPad('--helper=', 18));
   print('%s\t[true|false] stop spec execution on expectation failure', lPad('--stop-on-failure=', 18));

--- a/lib/command.js
+++ b/lib/command.js
@@ -78,6 +78,8 @@ function parseOptions(argv) {
   argv.forEach(function(arg) {
     if (arg === '--no-color') {
       color = false;
+    } else if (arg === '--force-color') {
+      color = true;
     } else if (arg.match("^--filter=")) {
       filter = arg.match("^--filter=(.*)")[1];
     } else if (arg.match("^--helper=")) {

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -198,7 +198,7 @@ describe('command', function() {
 
     it('should be able to force colors to be turned on', function() {
       withValueForIsTTY(undefined, function () {
-        this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--force-color']);
+        this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--color']);
         expect(this.fakeJasmine.showColors).toHaveBeenCalledWith(true);
       }.bind(this));
     });

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -196,6 +196,13 @@ describe('command', function() {
       expect(this.fakeJasmine.showColors).toHaveBeenCalledWith(false);
     });
 
+    it('should be able to force colors to be turned on', function() {
+      withValueForIsTTY(undefined, function () {
+        this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--force-color']);
+        expect(this.fakeJasmine.showColors).toHaveBeenCalledWith(true);
+      }.bind(this));
+    });
+
     it('should execute the jasmine suite', function() {
       this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js']);
       expect(this.fakeJasmine.execute).toHaveBeenCalled();


### PR DESCRIPTION
`jasmine` automatically turns off colors when its output target is not tty, while it only has `--no-color` option which forces jasmine **not** to color its result.
However, when redirecting its result through non-tty to tty, colors should be retained.

This patch adds `--force-color` option, which forces jasmine to color its result, regardless of its output target (tty or non-tty).

