### PR TITLE
Add option "require(s)"

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -65,6 +65,7 @@ function isFileArg(arg) {
 function parseOptions(argv) {
   var files = [],
       helpers = [],
+      requires = [],
       unknownOptions = [],
       color = process.stdout.isTTY || false,
       reporter,
@@ -84,6 +85,8 @@ function parseOptions(argv) {
       filter = arg.match("^--filter=(.*)")[1];
     } else if (arg.match("^--helper=")) {
       helpers.push(arg.match("^--helper=(.*)")[1]);
+    } else if (arg.match("^--require=")) {
+      requires.push(arg.match("^--require=(.*)")[1]);
     } else if (arg.match("^--stop-on-failure=")) {
       stopOnFailure = arg.match("^--stop-on-failure=(.*)")[1] === 'true';
     } else if (arg.match("^--fail-fast=")) {
@@ -109,6 +112,7 @@ function parseOptions(argv) {
     stopOnFailure: stopOnFailure,
     failFast: failFast,
     helpers: helpers,
+    requires: requires,
     reporter: reporter,
     files: files,
     random: random,
@@ -133,6 +137,9 @@ function runJasmine(jasmine, env, print) {
   }
   if (env.helpers !== undefined && env.helpers.length) {
     jasmine.addHelperFiles(env.helpers);
+  }
+  if (env.requires !== undefined && env.requires.length) {
+    jasmine.addRequires(env.requires);
   }
   if (env.reporter !== undefined) {
     try {
@@ -213,6 +220,7 @@ function help(options) {
   print('%s\tforce turn on color in spec output', lPad('--color', 18));
   print('%s\tfilter specs to run only those that match the given string', lPad('--filter=', 18));
   print('%s\tload helper files that match the given string', lPad('--helper=', 18));
+  print('%s\tload module that match the given string', lPad('--require=', 18));
   print('%s\t[true|false] stop spec execution on expectation failure', lPad('--stop-on-failure=', 18));
   print('%s\t[true|false] stop Jasmine execution on spec failure', lPad('--fail-fast=', 18));
   print('%s\tpath to your optional jasmine.json', lPad('--config=', 18));

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -16,6 +16,7 @@ function Jasmine(options) {
   this.specDir = '';
   this.specFiles = [];
   this.helperFiles = [];
+  this.requires = [];
   this.env = this.jasmine.getEnv({suppressLoadErrors: true});
   this.reportersCount = 0;
   this.completionReporter = new CompletionReporter();
@@ -95,6 +96,12 @@ Jasmine.prototype.loadHelpers = function() {
   });
 };
 
+Jasmine.prototype.loadRequires = function() {
+  this.requires.forEach(function(r) {
+    require(r);
+  });
+};
+
 Jasmine.prototype.loadConfigFile = function(configFilePath) {
   try {
     var absoluteConfigFilePath = path.resolve(this.projectBaseDir, configFilePath || 'spec/support/jasmine.json');
@@ -124,6 +131,10 @@ Jasmine.prototype.loadConfig = function(config) {
     this.addHelperFiles(config.helpers);
   }
 
+  if(config.requires) {
+    this.addRequires(config.requires);
+  }
+
   if(config.spec_files) {
     this.addSpecFiles(config.spec_files);
   }
@@ -131,6 +142,13 @@ Jasmine.prototype.loadConfig = function(config) {
 
 Jasmine.prototype.addHelperFiles = addFiles('helperFiles');
 Jasmine.prototype.addSpecFiles = addFiles('specFiles');
+
+Jasmine.prototype.addRequires = function(requires) {
+  var jasmineRunner = this;
+  requires.forEach(function(r) {
+    jasmineRunner.requires.push(r);
+  });
+};
 
 function addFiles(kind) {
   return function (files) {
@@ -184,6 +202,7 @@ Jasmine.prototype.execute = function(files, filterString) {
   process.on('exit', this.checkExit);
 
   this.loadHelpers();
+  this.loadRequires();
   if (!this.defaultReporterConfigured) {
     this.configureDefaultReporter({ showColors: this.showingColors });
   }

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -42,7 +42,7 @@ describe('command', function() {
 
     this.command = new Command(projectBaseDir, examplesDir, this.out.print);
 
-    this.fakeJasmine = jasmine.createSpyObj('jasmine', ['loadConfigFile', 'addHelperFiles', 'showColors', 'execute', 'stopSpecOnExpectationFailure',
+    this.fakeJasmine = jasmine.createSpyObj('jasmine', ['loadConfigFile', 'addHelperFiles', 'addRequires', 'showColors', 'execute', 'stopSpecOnExpectationFailure',
       'stopOnSpecFailure', 'randomizeTests', 'seed', 'coreVersion', 'clearReporters', 'addReporter']);
   });
 
@@ -231,6 +231,16 @@ describe('command', function() {
     it('should not modify helper patterns if no argument given', function() {
       this.command.run(this.fakeJasmine, []);
       expect(this.fakeJasmine.addHelperFiles).not.toHaveBeenCalled();
+    });
+
+    it('should be able to add one require', function() {
+      this.command.run(this.fakeJasmine, ['--require=ts-node/require']);
+      expect(this.fakeJasmine.addRequires).toHaveBeenCalledWith(['ts-node/require']);
+    });
+
+    it('should be able to add multiple requires', function() {
+      this.command.run(this.fakeJasmine, ['--require=ts-node/require', '--require=@babel/register']);
+      expect(this.fakeJasmine.addRequires).toHaveBeenCalledWith(['ts-node/require', '@babel/register']);
     });
 
     it('can specify a reporter', function() {

--- a/spec/fixtures/sample_project/spec/support/jasmine_alternate.json
+++ b/spec/fixtures/sample_project/spec/support/jasmine_alternate.json
@@ -6,5 +6,8 @@
   ],
   "helpers": [
     "helper.js"
+  ],
+  "requires": [
+    "ts-node/register"
   ]
 }

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -164,6 +164,9 @@ describe('Jasmine', function() {
           ],
           helpers: [
             "helper.js"
+          ],
+          requires: [
+            "ts-node/register"
           ]
         };
       });
@@ -171,6 +174,7 @@ describe('Jasmine', function() {
       it('adds unique specs to the jasmine runner', function() {
         this.fixtureJasmine.loadConfig(this.configObject);
         expect(this.fixtureJasmine.helperFiles).toEqual(['spec/fixtures/sample_project/spec/helper.js']);
+        expect(this.fixtureJasmine.requires).toEqual(['ts-node/register']);
         expect(this.fixtureJasmine.specFiles).toEqual([
           'spec/fixtures/sample_project/spec/fixture_spec.js',
           'spec/fixtures/sample_project/spec/other_fixture_spec.js'
@@ -241,6 +245,7 @@ describe('Jasmine', function() {
       it('adds unique specs to the jasmine runner', function() {
         this.fixtureJasmine.loadConfigFile('spec/support/jasmine_alternate.json');
         expect(this.fixtureJasmine.helperFiles).toEqual(['spec/fixtures/sample_project/spec/helper.js']);
+        expect(this.fixtureJasmine.requires).toEqual(['ts-node/register']);
         expect(this.fixtureJasmine.specFiles).toEqual([
           'spec/fixtures/sample_project/spec/fixture_spec.js',
           'spec/fixtures/sample_project/spec/other_fixture_spec.js'
@@ -251,6 +256,7 @@ describe('Jasmine', function() {
         var absoluteConfigPath = path.join(__dirname, 'fixtures/sample_project/spec/support/jasmine_alternate.json');
         this.fixtureJasmine.loadConfigFile(absoluteConfigPath);
         expect(this.fixtureJasmine.helperFiles).toEqual(['spec/fixtures/sample_project/spec/helper.js']);
+        expect(this.fixtureJasmine.requires).toEqual(['ts-node/register']);
         expect(this.fixtureJasmine.specFiles).toEqual([
           'spec/fixtures/sample_project/spec/fixture_spec.js',
           'spec/fixtures/sample_project/spec/other_fixture_spec.js'


### PR DESCRIPTION
As discussed in #135, add new option `--require` for CLI and `"requires": [ ]` for configuration file. A common use case is: `--require=ts-node/register`.

Although option `helper` can achieve the goal, there are two main reasons for this option:
1. Tools like mocha and istanbul have the same option.
2. It needs to create a separate helper js and require modules in that file.