### PR TITLE
Unknown command line options produce exit code 1

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -48,6 +48,7 @@ function Command(projectBaseDir, examplesDir, print) {
     } else {
       var env = parseOptions(commands);
       if (env.unknownOptions.length > 0) {
+        process.exitCode = 1;
         print('Unknown options: ' + env.unknownOptions.join(', '));
         print('');
         help({print: print});

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -113,10 +113,19 @@ describe('command', function() {
   });
 
   describe('passing unknown options', function() {
-    it('display unknown options and usage', function() {
+    beforeEach(function() {
+      this.exitCode = process.exitCode;
+    });
+
+    afterEach(function() {
+      process.exitCode = this.exitCode;
+    });
+
+    it('displays unknown options and usage', function() {
       this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--some-option', '--no-color', '--another-option']);
       expect(this.out.getOutput()).toContain('Unknown options: --some-option, --another-option');
       expect(this.out.getOutput()).toContain('Usage');
+      expect(process.exitCode).toBe(1);
     });
   });
 


### PR DESCRIPTION
### SUMMARY

Fix https://github.com/jasmine/jasmine-npm/issues/137 (by setting the exitCode to `1` if unknown options are present).

### DETAILS

Modify `Command` so that `process.exitCode` is set to `1` if unknown options are present.

There's a couple different places you could do this, but this seems most reasonable -- the way all existing error codes work is that `bin/jasmine.js` expects to _reach the end of file_, and then handle exit codes via the exit trap.  In our case, `runJasmine` is never called, so there will be no exit trap, but just setting exitCode and allowing the process to exit naturally gives an execution flow most similar to the existing flow.
