### PR TITLE
Wait until streams are completed before exiting

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -197,11 +197,22 @@ Jasmine.prototype.stopOnSpecFailure = function(value) {
 };
 
 Jasmine.prototype.exitCodeCompletion = function(passed) {
-  if(passed) {
-    this.exit(0);
-  }
-  else {
-    this.exit(1);
+  var jasmineRunner = this;
+  var streams = [process.stdout, process.stderr];
+  var writesToWait = streams.length;
+  streams.forEach(function(stream) {
+    stream.write('', exitIfAllStreamsCompleted);
+  });
+  function exitIfAllStreamsCompleted() {
+    writesToWait--;
+    if (writesToWait === 0) {
+      if(passed) {
+        jasmineRunner.exit(0);
+      }
+      else {
+        jasmineRunner.exit(1);
+      }
+    }
   }
 };
 

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -444,7 +444,9 @@ describe('Jasmine', function() {
         this.testJasmine.exit = exitSpy;
 
         this.testJasmine.exitCodeCompletion(true);
-        expect(exitSpy).toHaveBeenCalledWith(0);
+        sleep(10).then(function() {
+          expect(exitSpy).toHaveBeenCalledWith(0);
+        });
       });
 
       it('exits with a failure when anything in the suite is not green', function() {
@@ -452,8 +454,16 @@ describe('Jasmine', function() {
         this.testJasmine.exit = exitSpy;
 
         this.testJasmine.exitCodeCompletion(false);
-        expect(exitSpy).toHaveBeenCalledWith(1);
+        sleep(10).then(function() {
+          expect(exitSpy).toHaveBeenCalledWith(1);
+        });
       });
+
+      function sleep(ms) {
+        return new Promise(function(resolve) {
+          setTimeout(resolve, ms);
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
to prevent output cropping when jasmine is called from another process.
Cropping happens in some environments more often than others (might depend on shell).
Mostly happens when there is plenty of (error) output in buffer so it's not all flushed before process exit and is lost.

Same problem was in `jasmine-node`:
https://github.com/mhevery/jasmine-node/pull/420

Fix in that and in this PR is based on similar issue in mocha: https://github.com/mochajs/mocha/issues/333