### PR TITLE
Changes to avoid config deprecation warnings (from jasmine-core)

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -39,11 +39,11 @@ function Jasmine(options) {
 }
 
 Jasmine.prototype.randomizeTests = function(value) {
-  this.env.randomizeTests(value);
+  this.env.configure({random: value});
 };
 
 Jasmine.prototype.seed = function(value) {
-  this.env.seed(value);
+  this.env.configure({seed: value});
 };
 
 Jasmine.prototype.showColors = function(value) {
@@ -115,22 +115,22 @@ Jasmine.prototype.loadConfigFile = function(configFilePath) {
 Jasmine.prototype.loadConfig = function(config) {
   this.specDir = config.spec_dir || this.specDir;
 
-  var configOptions = {};
+  var configuration = {};
 
   if (config.stopSpecOnExpectationFailure !== undefined) {
-    configOptions.oneFailurePerSpec = config.stopSpecOnExpectationFailure;
+    configuration.oneFailurePerSpec = config.stopSpecOnExpectationFailure;
   }
 
   if (config.stopOnSpecFailure !== undefined) {
-    configOptions.failFast = config.stopOnSpecFailure;
+    configuration.failFast = config.stopOnSpecFailure;
   }
 
   if (config.random !== undefined) {
-    configOptions.random = config.random;
+    configuration.random = config.random;
   }
 
-  if (Object.keys(configOptions).length > 0) {
-    this.env.configure(configOptions);
+  if (Object.keys(configuration).length > 0) {
+    this.env.configure(configuration);
   }
 
   if(config.helpers) {
@@ -195,11 +195,11 @@ Jasmine.prototype.onComplete = function(onCompleteCallback) {
 };
 
 Jasmine.prototype.stopSpecOnExpectationFailure = function(value) {
-  this.env.throwOnExpectationFailure(value);
+  this.env.configure({oneFailurePerSpec: value});
 };
 
 Jasmine.prototype.stopOnSpecFailure = function(value) {
-  this.env.stopOnSpecFailure(value);
+  this.env.configure({failFast: value});
 };
 
 Jasmine.prototype.exitCodeCompletion = function(passed) {
@@ -243,9 +243,9 @@ Jasmine.prototype.execute = function(files, filterString) {
     var specFilter = new ConsoleSpecFilter({
       filterString: filterString
     });
-    this.env.specFilter = function(spec) {
+    this.env.configure({specFilter: function(spec) {
       return specFilter.matches(spec.getFullName());
-    };
+    }});
   }
 
   if (files && files.length > 0) {

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -11,9 +11,6 @@ describe('Jasmine', function() {
         addMatchers: jasmine.createSpy('addMatchers'),
         provideFallbackReporter: jasmine.createSpy('provideFallbackReporter'),
         execute: jasmine.createSpy('execute'),
-        throwOnExpectationFailure: jasmine.createSpy('throwOnExpectationFailure'),
-        stopOnSpecFailure: jasmine.createSpy('stopOnSpecFailure'),
-        randomizeTests: jasmine.createSpy('randomizeTests'),
         configure: jasmine.createSpy('configure')
       }),
       Timer: jasmine.createSpy('Timer')
@@ -297,21 +294,21 @@ describe('Jasmine', function() {
   describe('#stopSpecOnExpectationFailure', function() {
     it('sets the throwOnExpectationFailure value on the jasmine-core env', function() {
       this.testJasmine.stopSpecOnExpectationFailure('foobar');
-      expect(this.testJasmine.env.throwOnExpectationFailure).toHaveBeenCalledWith('foobar');
+      expect(this.testJasmine.env.configure).toHaveBeenCalledWith({oneFailurePerSpec: 'foobar'});
     });
   });
 
   describe('#stopOnSpecFailure', function() {
     it('sets the stopOnSpecFailure value on the jasmine-core env', function() {
       this.testJasmine.stopOnSpecFailure('blah');
-      expect(this.testJasmine.env.stopOnSpecFailure).toHaveBeenCalledWith('blah');
+      expect(this.testJasmine.env.configure).toHaveBeenCalledWith({failFast: 'blah'});
     });
   });
 
   describe('#randomizeTests', function() {
     it('sets the randomizeTests value on the jasmine-core env', function() {
       this.testJasmine.randomizeTests('foobar');
-      expect(this.testJasmine.env.randomizeTests).toHaveBeenCalledWith('foobar');
+      expect(this.testJasmine.env.configure).toHaveBeenCalledWith({random: 'foobar'});
     });
   });
 
@@ -402,7 +399,7 @@ describe('Jasmine', function() {
       this.testJasmine.loadConfigFile();
 
       this.testJasmine.execute(['spec/fixtures/**/*spec.js'], 'interesting spec');
-      expect(this.testJasmine.env.specFilter).toEqual(jasmine.any(Function));
+      expect(this.testJasmine.env.configure).toHaveBeenCalledWith({specFilter: jasmine.any(Function)});
     });
 
     it('adds an exit code reporter', function() {


### PR DESCRIPTION
Change the way that certain configuration options are set to Jasmine's environment to be compliant with jasmine-core and avoid deprecation warnings.