### PR TITLE
Remove listener

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -233,7 +233,7 @@ var checkExit = function(jasmineRunner) {
 };
 
 Jasmine.prototype.execute = function(files, filterString) {
-  process.on('exit', this.checkExit);
+  this.completionReporter.exitHandler = this.checkExit;
 
   this.loadRequires();
   this.loadHelpers();

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -182,7 +182,9 @@ function addFiles(kind) {
       }
       var filePaths = glob.sync(file, { ignore: excludeFiles });
       filePaths.forEach(function(filePath) {
-        if(fileArr.indexOf(filePath) === -1) {
+        // glob will always output '/' as a segment separator but the fileArr may use \ on windows
+        // fileArr needs to be checked for both versions
+        if(fileArr.indexOf(filePath) === -1 && fileArr.indexOf(path.normalize(filePath)) === -1) {
           fileArr.push(filePath);
         }
       });

--- a/lib/reporters/completion_reporter.js
+++ b/lib/reporters/completion_reporter.js
@@ -6,12 +6,24 @@ module.exports = function() {
     onCompleteCallback = callback;
   };
 
+  this.jasmineStarted = function() {
+    if (this.exitHandler) {
+      process.on('exit', this.exitHandler);
+    }
+  };
+
   this.jasmineDone = function(result) {
     completed = true;
+    if (this.exitHandler) {
+      process.off('exit', this.exitHandler);
+    }
+
     onCompleteCallback(result.overallStatus === 'passed');
   };
 
   this.isComplete = function() {
     return completed;
   };
+
+  this.exitHandler = null;
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt": "^1.0.3",
     "grunt-cli": "^1.3.2",
     "grunt-contrib-jshint": "^2.0.0",
-    "shelljs": "^0.8.3"
+    "shelljs": "^0.8.3",
+    "slash": "^2.0.0"
   }
 }

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -1,6 +1,6 @@
 describe('Jasmine', function() {
   var path = require('path'),
-      util = require('util'),
+      slash = require('slash'),
       Jasmine = require('../lib/jasmine');
 
   beforeEach(function() {
@@ -52,7 +52,7 @@ describe('Jasmine', function() {
       var aFile = path.join(this.testJasmine.projectBaseDir, this.testJasmine.specDir, 'spec/command_spec.js');
       expect(this.testJasmine.specFiles).toEqual([]);
       this.testJasmine.addSpecFiles([aFile]);
-      expect(this.testJasmine.specFiles).toEqual([aFile]);
+      expect(this.testJasmine.specFiles).toEqual([slash(aFile)]);
     });
 
     it('add spec files with glob pattern', function() {
@@ -138,7 +138,7 @@ describe('Jasmine', function() {
         print: jasmine.any(Function),
         showColors: true,
         timer: jasmine.any(Object),
-        jasmineCorePath: 'fake/jasmine/path/jasmine.js'
+        jasmineCorePath: path.normalize('fake/jasmine/path/jasmine.js')
       };
 
       expect(this.testJasmine.reporter.setOptions).toHaveBeenCalledWith(expectedReporterOptions);
@@ -285,7 +285,7 @@ describe('Jasmine', function() {
       it('loads the default configuration file', function() {
         this.fixtureJasmine.loadConfigFile();
         expect(this.fixtureJasmine.specFiles).toEqual([
-          'spec/fixtures/sample_project/spec/fixture_spec.js',
+          'spec/fixtures/sample_project/spec/fixture_spec.js'
         ]);
       });
     });
@@ -388,11 +388,11 @@ describe('Jasmine', function() {
 
       this.testJasmine.execute(['spec/fixtures/**/*spec.js']);
 
-      var relativePaths = this.testJasmine.specFiles.map(function(path) {
-        return path.replace(__dirname, '');
+      var relativePaths = this.testJasmine.specFiles.map(function(filePath) {
+        return slash(path.relative(__dirname, filePath));
       });
 
-      expect(relativePaths).toEqual(['/fixtures/sample_project/spec/fixture_spec.js', '/fixtures/sample_project/spec/other_fixture_spec.js']);
+      expect(relativePaths).toEqual(['fixtures/sample_project/spec/fixture_spec.js', 'fixtures/sample_project/spec/other_fixture_spec.js']);
     });
 
     it('should add spec filter if filterString is provided', function() {

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -26,12 +26,6 @@ describe('Jasmine', function() {
     this.testJasmine = new Jasmine({ jasmineCore: this.fakeJasmineCore });
   });
 
-  afterEach(function() {
-    if (this.testJasmine.checkExit) {
-      process.removeListener('exit', this.testJasmine.checkExit);
-    }
-  });
-
   describe('constructor options', function() {
     it('have defaults', function() {
       expect(this.testJasmine.projectBaseDir).toEqual(path.resolve());
@@ -410,6 +404,7 @@ describe('Jasmine', function() {
       this.testJasmine.execute();
 
       expect(this.testJasmine.addReporter).toHaveBeenCalledWith(completionReporterSpy);
+      expect(this.testJasmine.completionReporter.exitHandler).toBe(this.testJasmine.checkExit);
     });
 
     describe('when exit is called prematurely', function() {

--- a/spec/reporters/completion_reporter_spec.js
+++ b/spec/reporters/completion_reporter_spec.js
@@ -5,6 +5,8 @@ describe('CompletionReporter', function() {
     this.reporter = new CompletionReporter();
     this.onComplete = jasmine.createSpy('onComplete');
     this.reporter.onComplete(this.onComplete);
+    this.processOn = spyOn(process, 'on').and.callThrough();
+    this.processOff = spyOn(process, 'off').and.callThrough();
   });
 
   describe('When the overall status is "passed"', function() {
@@ -18,6 +20,23 @@ describe('CompletionReporter', function() {
     it('calls the completion callback with false', function() {
       this.reporter.jasmineDone({overallStatus: 'incomplete'});
       expect(this.onComplete).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('When jasmine is started and done', function() {
+    it('adds and removes the exit handler', function() {
+      this.reporter.exitHandler = function() {};
+      this.reporter.jasmineStarted();
+      this.reporter.jasmineDone({overallStatus: 'passed'});
+      expect(this.processOn).toHaveBeenCalledWith('exit', this.reporter.exitHandler);
+      expect(this.processOff).toHaveBeenCalledWith('exit', this.reporter.exitHandler);
+    });
+
+    it('ignores the exit event if there is no exit handler', function() {
+      this.reporter.jasmineStarted();
+      this.reporter.jasmineDone({overallStatus: 'passed'});
+      expect(this.processOn).toHaveBeenCalledTimes(0);
+      expect(this.processOff).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
Currently jasmine-npm does not remove the exit listener it adds when it executes. This pull moves the exit listener code completely within the completion reporter so that the listener can be added and removed whenever jasmine is started and done. This is basically pull #125 , except that the jasmine interface remains as intact as possible. The only interface change is that the completion reporter now uses jasmineStarted to add the exit listener. The jasmineStarted method can no longer be overwritten without losing the exit check logic. You can close issue #134 after merging. The fix should allow jasmine to be used with things like gulp watch without errors about max listeners.

Unfortunatly I also had to make failing tests pass on Windows since file logic relied on path separators only being / when windows also allows \\. The fix will probably make it so that on windows, files aren't required twice. I don't actually think requiring a file twice does any harm, especially with how it is used here.

Unrelated, but I found it ironic that the tests were smart enough to remove the exit listener while the actual code it was testing was not.