### PR TITLE
not parsing argv after --

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -78,7 +78,8 @@ function parseOptions(argv) {
       seed,
       workerCount;
 
-  argv.forEach(function(arg) {
+  for (var i in argv) {
+    var arg = argv[i];
     if (arg === '--no-color') {
       color = false;
     } else if (arg === '--color') {
@@ -103,12 +104,14 @@ function parseOptions(argv) {
       configPath = arg.match("^--config=(.*)")[1];
     } else if (arg.match("^--reporter=")) {
       reporter = arg.match("^--reporter=(.*)")[1];
+    } else if (arg === '--') {
+      break;
     } else if (isFileArg(arg)) {
       files.push(arg);
     } else if (!isEnvironmentVariable(arg)) {
       unknownOptions.push(arg);
     }
-  });
+  }
   return {
     color: color,
     configPath: configPath,
@@ -180,7 +183,7 @@ function installExamples(options) {
 
 function help(options) {
   var print = options.print;
-  print('Usage: jasmine [command] [options] [files]');
+  print('Usage: jasmine [command] [options] [files] [--]');
   print('');
   print('Commands:');
   Object.keys(subCommands).forEach(function(cmd) {
@@ -206,6 +209,7 @@ function help(options) {
   print('%s\tpath to your optional jasmine.json', lPad('--config=', 18));
   print('%s\tpath to reporter to use instead of the default Jasmine reporter', lPad('--reporter=', 18));
   print('%s\tnumber of workers to run the tests in parallel. Default is 1', lPad('--worker-count=', 18));
+  print('%s\tmarker to signal the end of options meant for Jasmine', lPad('--', 18));
   print('');
   print('The given arguments take precedence over options in your jasmine.json');
   print('The path to your optional jasmine.json can also be configured by setting the JASMINE_CONFIG_PATH environment variable');

--- a/spec/command_spec.js
+++ b/spec/command_spec.js
@@ -129,6 +129,14 @@ describe('command', function() {
     });
   });
 
+  describe('--', function() {
+    it('skips anything after it', function() {
+      this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', '--', '--no-color']);
+      expect(this.out.getOutput()).toBe('');
+      expect(this.fakeJasmine.showColors).toHaveBeenCalledWith(true);
+    });
+  });
+
   describe('examples', function() {
     beforeEach(function() {
       this.command.run(this.fakeJasmine, ['node', 'bin/jasmine.js', 'examples']);


### PR DESCRIPTION
To allow for classic getopts argv parsing, one could now use `--` also to separate arguments meant for the process from the ones for the subprocess (here, the tests run by jasmine).
So now, one could do `node jasmine.js -- test-specific-arguments`.
A nicer fix would be to provide the extracted subprocess arguments via a specific arguments list, such as `jasmine.argv`, to avoid redoing part of parsing.