### PR TITLE
Support 'failSpecWithNoExpectations' config option

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -120,6 +120,10 @@ Jasmine.prototype.loadConfig = function(config) {
 
   var configuration = {};
 
+  if (config.failSpecWithNoExpectations !== undefined) {
+    configuration.failSpecWithNoExpectations = config.failSpecWithNoExpectations;
+  }
+
   if (config.stopSpecOnExpectationFailure !== undefined) {
     configuration.oneFailurePerSpec = config.stopSpecOnExpectationFailure;
   }

--- a/lib/reporters/console_reporter.js
+++ b/lib/reporters/console_reporter.js
@@ -202,6 +202,21 @@ function ConsoleReporter() {
       printNewline();
       print(indent(stackFilter(failedExpectation.stack), 4));
     }
+    
+    // When failSpecWithNoExpectations = true and a spec fails because of no expectations found,
+    // jasmine-core reports it as a failure with no message.
+    //
+    // Therefore we assume that when there are no failed or passed expectations,
+    // the failure was because of our failSpecWithNoExpectations setting.
+    //
+    // Same logic is used by jasmine.HtmlReporter, see https://github.com/jasmine/jasmine/blob/master/src/html/HtmlReporter.js
+    if (result.failedExpectations.length === 0 &&
+        (!result.passedExpectations || result.passedExpectations.length === 0)) {
+      printNewline();
+      print(indent('Message:', 2));
+      printNewline();
+      print(colored('red', indent('Spec has no expectations', 4)));
+    }
 
     printNewline();
   }

--- a/spec/jasmine_spec.js
+++ b/spec/jasmine_spec.js
@@ -179,6 +179,13 @@ describe('Jasmine', function() {
         ]);
       });
 
+      it('can tell jasmine-core to stop spec on no expectations', function() {
+        this.configObject.failSpecWithNoExpectations = true;
+        this.fixtureJasmine.loadConfig(this.configObject);
+
+        expect(this.fixtureJasmine.env.configure).toHaveBeenCalledWith({failSpecWithNoExpectations: true});
+      });
+
       it('can tell jasmine-core to stop spec on expectation failure', function() {
         this.configObject.stopSpecOnExpectationFailure = true;
         this.fixtureJasmine.loadConfig(this.configObject);
@@ -212,7 +219,7 @@ describe('Jasmine', function() {
         expect(this.fixtureJasmine.env.configure).toHaveBeenCalledWith({random: true});
       });
 
-      it('uses jasmine-core defaults if random is unspecified', function() {
+      it('uses jasmine-core defaults if no config options specified', function() {
         this.fixtureJasmine.loadConfig(this.configObject);
 
         expect(this.fixtureJasmine.env.configure).not.toHaveBeenCalled();

--- a/spec/reporters/console_reporter_spec.js
+++ b/spec/reporters/console_reporter_spec.js
@@ -408,6 +408,102 @@ describe("ConsoleReporter", function() {
     expect(this.out.getOutput()).toContain("Incomplete: not all bars were frobnicated");
   });
 
+  it("reports a summary when done that shows info for a failed spec with no expectations", function() {
+    var reporter = new ConsoleReporter();
+    reporter.setOptions({
+      print: this.out.print,
+      jasmineCorePath: jasmineCorePath
+    });
+
+    reporter.jasmineStarted();
+    reporter.specDone({status: "passed"});
+    reporter.specDone({
+      status: "failed",
+      description: "with a failing spec",
+      fullName: "A suite with a failing spec that has no expectations",
+      failedExpectations: []
+    });
+
+    this.out.clear();
+
+    reporter.jasmineDone();
+
+    expect(this.out.getOutput()).toContain("Spec has no expectations");
+  });
+
+  it('reports a summary without "no expectations" message for a spec having failed expectations', function () {
+    var reporter = new ConsoleReporter();
+    reporter.setOptions({
+      print: this.out.print,
+      jasmineCorePath: jasmineCorePath
+    });
+
+    reporter.jasmineStarted();
+    reporter.specDone({
+      status: "failed",
+      description: "with a failing spec",
+      fullName: "A suite with a failing spec that has a failing expectation",
+      failedExpectations: [{
+        passed: false,
+        message: "Expected true to be false.",
+        expected: false,
+        actual: true,
+        stack: undefined
+      }]
+    });
+
+    this.out.clear();
+
+    reporter.jasmineDone();
+
+    expect(this.out.getOutput()).not.toContain("Spec has no expectations");
+  });
+
+  it('reports a summary without a "no expectations" message for a spec having passed expectations', function () {
+    var reporter = new ConsoleReporter();
+    reporter.setOptions({
+      print: this.out.print,
+      jasmineCorePath: jasmineCorePath
+    });
+
+    reporter.jasmineStarted();
+    reporter.specDone({
+      status: "passed",
+      description: "with a passed spec",
+      fullName: "A suite with a passed spec",
+      passedExpectations: [{
+        passed: true,
+        message: "Expected true to be true.",
+        expected: true,
+        actual: true
+      }]
+    });
+    reporter.specDone({
+      status: "failed",
+      description: "with a failing spec",
+      fullName: "A suite with a failing spec that has both passed and failing expectations",
+      failedExpectations: [{
+        passed: false,
+        message: "Expected true to be false.",
+        expected: false,
+        actual: true,
+        stack: undefined
+      }],
+      passedExpectations: [{
+        passed: true,
+        message: "Expected true to be true.",
+        expected: true,
+        actual: true
+      }]
+    });
+
+    this.out.clear();
+
+    reporter.jasmineDone();
+
+    expect(this.out.getOutput()).not.toContain("Spec has no expectations");
+  });  
+
   it("displays all afterAll exceptions", function() {
     var reporter = new ConsoleReporter();
     reporter.setOptions({


### PR DESCRIPTION
This adds support for `failSpecWithNoExpectations` when calling loadConfig() or in jasmine.json.
It also modifies the default ConsoleReporter to print 'Spec has no expectations' when `failSpecWithNoExpectations=true` and a spec with no expect() is found.

Documentation update is here: https://github.com/jasmine/jasmine.github.io/pull/127

- Fixes #156