### PR TITLE
Provide useful output when require call failed when loading in specs

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -86,7 +86,13 @@ Jasmine.prototype.addMatchers = function(matchers) {
 
 Jasmine.prototype.loadSpecs = function() {
   this.specFiles.forEach(function(file) {
-    require(file);
+    try {
+      require(file);
+    }
+    catch (ex) {
+      console.error(ex);
+      process.exit(1);
+    }
   });
 };
 


### PR DESCRIPTION
This is useful for `ts-node` environments. If the require'd typescript file has typescript compilation errors, current release won't provide any error feedback, and execution just stops.

This change will print out error information from the `require` failure.