### PR TITLE
use the configured loader to load the reporter

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -166,7 +166,7 @@ async function registerReporter(reporterModuleName, jasmine) {
   let Reporter;
 
   try {
-    Reporter = await new Loader().load(resolveReporter(reporterModuleName));
+    Reporter = await (jasmine.loader || new Loader()).load(resolveReporter(reporterModuleName));
   } catch (e) {
     throw new Error('Failed to load reporter module '+ reporterModuleName +
       '\nUnderlying error: ' + e.stack + '\n(end underlying error)');


### PR DESCRIPTION
Fixes https://github.com/jasmine/jasmine-npm/issues/189 by using the pre-configured `jasmine.loader` when available to load the reporter.