### PR TITLE
Upgrade dependency: glob@8.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "glob": "^7.1.6",
+    "glob": "^8.0.3",
     "jasmine-core": "^4.4.0"
   },
   "bin": "./bin/jasmine.js",


### PR DESCRIPTION
glob 7.x depends on the path-is-absolute package. glob 8.x does not. Switching Jasmine to glob 8.x reduces npm package bloat.

The following changes in this commit are visible to Jasmine users:

> * `\` is now **only** used as an escape character, and never as a
>   path separator in glob patterns, so that Windows users have a
>   way to match against filenames containing literal glob pattern
>   characters.
> * Glob pattern paths **must** use forward-slashes as path
>   separators, since `\` is an escape character to match literal
>   glob pattern characters.

https://github.com/isaacs/node-glob/blob/v8.0.3/changelog.md#80