### PR TITLE
feat(sharding): Support sharding

### DIFF
--- a/lib/sharded_runner.js
+++ b/lib/sharded_runner.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
+const ConsoleReporter = require('./reporters/console_reporter');
 
 class ShardedRunner {
   constructor(options) {
@@ -33,13 +34,11 @@ class ShardedRunner {
 
     this.specDir = config.spec_dir || this.specDir;
 
-    // Load spec files using the same pattern as Jasmine's addMatchingSpecFiles
     if (config.spec_files) {
       const allSpecFiles = this.addMatchingFiles(config.spec_files);
       this.specFiles = this.filterFilesToShard(allSpecFiles);
     }
 
-    // Load helper files
     if (config.helpers) {
       this.helperFiles = this.addMatchingFiles(config.helpers);
     }
@@ -58,7 +57,6 @@ class ShardedRunner {
   addMatchingFiles(patterns) {
     const files = [];
 
-    // Separate include and exclude patterns
     const {includeFiles, excludeFiles} = patterns.reduce((ongoing, file) => {
       const hasNegation = file.startsWith('!');
 
@@ -101,7 +99,7 @@ class ShardedRunner {
     if (!files || files.length === 0) return [];
 
     const sortedFiles = files.slice().sort();
-    return sortedFiles.filter((file, index) =>
+    return sortedFiles.filter((_, index) =>
       index % this.shardCount === this.shardIndex
     );
   }
@@ -110,12 +108,15 @@ class ShardedRunner {
     const jasmineInterface = this.jasmineCore.noGlobals();
     const env = jasmineInterface.jasmine.getEnv();
 
-    // Set up globals needed by specs and helpers
     for (const key in jasmineInterface) {
       globalThis[key] = jasmineInterface[key];
     }
 
     env.configure(this.jasmineConfig);
+
+    if (ConsoleReporter) {
+      env.addReporter(new ConsoleReporter());
+    }
 
     for (const requireFile of this.requireFiles) {
       require(requireFile);

--- a/lib/sharded_runner.js
+++ b/lib/sharded_runner.js
@@ -1,0 +1,143 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+class ShardedRunner {
+  constructor(options) {
+    this.jasmineCore = options.jasmineCore;
+    this.shardIndex = options.shardIndex;
+    this.shardCount = options.shardCount;
+    this.exitOnCompletion = true;
+
+    this.specFiles = [];
+    this.helperFiles = [];
+    this.requireFiles = [];
+    this.projectBaseDir = process.cwd();
+    this.specDir = 'spec';
+    this.jasmineConfig = {};
+  }
+
+  async loadConfigFile(configPath) {
+    const fullPath = path.resolve(this.projectBaseDir, configPath);
+
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`Config file not found: ${fullPath}`);
+    }
+
+    let config;
+    try {
+      config = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+    } catch (e) {
+      throw new Error(`Failed to parse config file ${fullPath}: ${e.message}`);
+    }
+
+    this.specDir = config.spec_dir || this.specDir;
+
+    // Load spec files using the same pattern as Jasmine's addMatchingSpecFiles
+    if (config.spec_files) {
+      const allSpecFiles = this.addMatchingFiles(config.spec_files);
+      this.specFiles = this.filterFilesToShard(allSpecFiles);
+    }
+
+    // Load helper files
+    if (config.helpers) {
+      this.helperFiles = this.addMatchingFiles(config.helpers);
+    }
+
+    this.requireFiles = config.requires || [];
+
+    this.jasmineConfig = {
+      random: config.random,
+      seed: config.seed,
+      stopOnSpecFailure: config.stopOnSpecFailure,
+      failSpecWithNoExpectations: config.failSpecWithNoExpectations,
+      stopSpecOnExpectationFailure: config.stopSpecOnExpectationFailure
+    };
+  }
+
+  addMatchingFiles(patterns) {
+    const files = [];
+
+    // Separate include and exclude patterns
+    const {includeFiles, excludeFiles} = patterns.reduce((ongoing, file) => {
+      const hasNegation = file.startsWith('!');
+
+      if (hasNegation) {
+        file = file.substring(1);
+      }
+
+      return {
+        includeFiles: ongoing.includeFiles.concat(!hasNegation ? [file] : []),
+        excludeFiles: ongoing.excludeFiles.concat(hasNegation ? [file] : [])
+      };
+    }, { includeFiles: [], excludeFiles: [] });
+
+    const baseDir = path.resolve(this.projectBaseDir, this.specDir);
+
+    includeFiles.forEach(file => {
+      const filePaths = glob
+        .sync(file, { cwd: baseDir, ignore: excludeFiles })
+        .map(f => {
+          if (path.isAbsolute(f)) {
+            return f;
+          } else {
+            return path.resolve(baseDir, f);
+          }
+        })
+        .filter(filePath => {
+          return files.indexOf(filePath) === -1;
+        })
+        .sort();
+
+      filePaths.forEach(filePath => {
+        files.push(filePath);
+      });
+    });
+
+    return files;
+  }
+
+  filterFilesToShard(files) {
+    if (!files || files.length === 0) return [];
+
+    const sortedFiles = files.slice().sort();
+    return sortedFiles.filter((file, index) =>
+      index % this.shardCount === this.shardIndex
+    );
+  }
+
+  async execute() {
+    const jasmineInterface = this.jasmineCore.noGlobals();
+    const env = jasmineInterface.jasmine.getEnv();
+
+    // Set up globals needed by specs and helpers
+    for (const key in jasmineInterface) {
+      globalThis[key] = jasmineInterface[key];
+    }
+
+    env.configure(this.jasmineConfig);
+
+    for (const requireFile of this.requireFiles) {
+      require(requireFile);
+    }
+
+    for (const helperFile of this.helperFiles) {
+      require(path.resolve(helperFile));
+    }
+
+    for (const specFile of this.specFiles) {
+      require(path.resolve(specFile));
+    }
+
+    return new Promise((resolve) => {
+      env.execute().then(result => {
+        if (this.exitOnCompletion) {
+          process.exit(result.overallStatus === 'passed' ? 0 : 1);
+        }
+        resolve(result);
+      });
+    });
+  }
+}
+
+module.exports = ShardedRunner;

--- a/lib/sharded_runner.js
+++ b/lib/sharded_runner.js
@@ -8,7 +8,12 @@ class ShardedRunner {
     this.jasmineCore = options.jasmineCore;
     this.shardIndex = options.shardIndex;
     this.shardCount = options.shardCount;
+    this.globals = options.globals !== false;
     this.exitOnCompletion = true;
+    this.reporter_ = new (options.ConsoleReporter || ConsoleReporter)();
+    this.defaultReporterConfigured = false;
+    this.showingColors = true;
+    this.alwaysListPendingSpecs_ = true;
 
     this.specFiles = [];
     this.helperFiles = [];
@@ -104,19 +109,37 @@ class ShardedRunner {
     );
   }
 
-  async execute() {
-    const jasmineInterface = this.jasmineCore.noGlobals();
-    const env = jasmineInterface.jasmine.getEnv();
+  configureDefaultReporter(options) {
+    const util = require('util');
+    options.print = options.print || function() {
+      process.stdout.write(util.format.apply(this, arguments));
+    };
+    options.showColors = options.hasOwnProperty('showColors') ? options.showColors : true;
 
-    for (const key in jasmineInterface) {
-      globalThis[key] = jasmineInterface[key];
+    this.reporter_.setOptions(options);
+    this.defaultReporterConfigured = true;
+  }
+
+  async execute() {
+    let env;
+
+    if (this.globals === false) {
+      env = this.jasmineCore.noGlobals().jasmine.getEnv();
+    } else {
+      const bootedCore = this.jasmineCore.boot(this.jasmineCore);
+      env = bootedCore.getEnv();
     }
 
     env.configure(this.jasmineConfig);
 
-    if (ConsoleReporter) {
-      env.addReporter(new ConsoleReporter());
+    if (!this.defaultReporterConfigured) {
+      this.configureDefaultReporter({
+        showColors: this.showingColors,
+        alwaysListPendingSpecs: this.alwaysListPendingSpecs_
+      });
     }
+
+    env.addReporter(this.reporter_);
 
     for (const requireFile of this.requireFiles) {
       require(requireFile);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "exports": {
     ".": "./lib/jasmine.js",
-    "./parallel": "./lib/parallel_runner.js"
+    "./parallel": "./lib/parallel_runner.js",
+    "./sharded": "./lib/sharded_runner.js"
   },
   "files": [
     "bin",

--- a/spec/sharded_runner_cli_spec.js
+++ b/spec/sharded_runner_cli_spec.js
@@ -80,7 +80,6 @@ describe('jasmine-sharded CLI', function() {
     it('accepts valid shard format', async function() {
       const result = await runShardedCli(['--shard=1/4'], 'spec/fixtures/sample_project');
 
-      // Should not fail on argument parsing (though may fail on missing specs)
       expect(result.stderr).not.toContain('Invalid shard format');
       expect(result.stderr).not.toContain('Invalid shard index');
     });
@@ -108,7 +107,6 @@ describe('jasmine-sharded CLI', function() {
 
       expect(result.exitCode).toBe(1);
       expect(result.output).toContain('Config file not found');
-      // Should not crash or show stack trace
       expect(result.output).not.toContain('at ');
     });
   });
@@ -117,7 +115,6 @@ describe('jasmine-sharded CLI', function() {
     it('converts 1-based input to 0-based internally', async function() {
       const result = await runShardedCli(['--shard=1/2'], 'spec/fixtures/sample_project');
 
-      // Should not fail on conversion
       expect(result.stdout).toContain('Running shard 1/2');
       expect(result.stdout).toContain('Loaded');
       expect(result.stdout).toContain('spec files for this shard');
@@ -141,18 +138,11 @@ describe('jasmine-sharded CLI', function() {
     });
 
     it('handles empty shard gracefully', async function() {
-      // Use a high shard count to ensure some shards will be empty
       const result = await runShardedCli(['--shard=4/4'], 'spec/fixtures/sample_project');
 
-      if (result.stdout.includes('No spec files to run')) {
-        expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('Running shard 4/4');
-        expect(result.stdout).toContain('No spec files to run in this shard');
-      } else {
-        // If this shard isn't empty, that's also valid
-        expect(result.stdout).toContain('Running shard 4/4');
-        expect(result.stdout).toContain('Loaded');
-      }
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Running shard 4/4');
+      expect(result.stdout).toContain('No spec files to run in this shard');
     });
   });
 });

--- a/spec/sharded_runner_cli_spec.js
+++ b/spec/sharded_runner_cli_spec.js
@@ -1,0 +1,158 @@
+const { spawn } = require('child_process');
+
+describe('jasmine-sharded CLI', function() {
+  function runShardedCli(args, cwd = '.') {
+    return new Promise((resolve) => {
+      const path = require('path');
+      const cliPath = path.join(__dirname, '..', 'bin', 'jasmine-sharded.js');
+      const cliArgs = [cliPath].concat(args);
+      const child = spawn('node', cliArgs, {
+        cwd,
+        stdio: 'pipe'
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.on('close', (code) => {
+        resolve({
+          exitCode: code,
+          output: stdout + stderr,
+          stdout: stdout.trim(),
+          stderr: stderr.trim()
+        });
+      });
+    });
+  }
+
+  describe('argument parsing', function() {
+    it('shows help with --help', async function() {
+      const result = await runShardedCli(['--help']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Usage: jasmine-sharded');
+      expect(result.stdout).toContain('--shard=N/M');
+    });
+
+    it('shows help with -h', async function() {
+      const result = await runShardedCli(['-h']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Usage: jasmine-sharded');
+    });
+
+    it('requires shard argument', async function() {
+      const result = await runShardedCli([]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--shard argument is required');
+    });
+
+    it('rejects invalid shard format', async function() {
+      const result = await runShardedCli(['--shard=invalid']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid shard format');
+    });
+
+    it('rejects shard index of 0', async function() {
+      const result = await runShardedCli(['--shard=0/4']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid shard index: 0');
+    });
+
+    it('rejects shard index greater than total', async function() {
+      const result = await runShardedCli(['--shard=5/4']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid shard index: 5');
+    });
+
+    it('accepts valid shard format', async function() {
+      const result = await runShardedCli(['--shard=1/4'], 'spec/fixtures/sample_project');
+
+      // Should not fail on argument parsing (though may fail on missing specs)
+      expect(result.stderr).not.toContain('Invalid shard format');
+      expect(result.stderr).not.toContain('Invalid shard index');
+    });
+  });
+
+  describe('config file handling', function() {
+    it('uses default config path', async function() {
+      const result = await runShardedCli(['--shard=1/4'], 'lib');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('Config file not found');
+      expect(result.output).toContain('spec/support/jasmine.json');
+    });
+
+    it('uses custom config path', async function() {
+      const result = await runShardedCli(['--shard=1/4', '--config=nonexistent.json']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Config file not found');
+      expect(result.stderr).toContain('nonexistent.json');
+    });
+
+    it('handles missing config file gracefully', async function() {
+      const result = await runShardedCli(['--shard=1/4'], 'lib');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('Config file not found');
+      // Should not crash or show stack trace
+      expect(result.output).not.toContain('at ');
+    });
+  });
+
+  describe('1-based to 0-based conversion', function() {
+    it('converts 1-based input to 0-based internally', async function() {
+      const result = await runShardedCli(['--shard=1/2'], 'spec/fixtures/sample_project');
+
+      // Should not fail on conversion
+      expect(result.stdout).toContain('Running shard 1/2');
+      expect(result.stdout).toContain('Loaded');
+      expect(result.stdout).toContain('spec files for this shard');
+    });
+
+    it('handles edge case of last shard', async function() {
+      const result = await runShardedCli(['--shard=2/2'], 'spec/fixtures/sample_project');
+
+      expect(result.stdout).toContain('Running shard 2/2');
+      expect(result.stdout).toContain('Loaded');
+    });
+  });
+
+  describe('output formatting', function() {
+    it('shows shard information', async function() {
+      const result = await runShardedCli(['--shard=1/4'], 'spec/fixtures/sample_project');
+
+      expect(result.stdout).toContain('Running shard 1/4');
+      expect(result.stdout).toContain('Loaded');
+      expect(result.stdout).toContain('spec files for this shard');
+    });
+
+    it('handles empty shard gracefully', async function() {
+      // Use a high shard count to ensure some shards will be empty
+      const result = await runShardedCli(['--shard=4/4'], 'spec/fixtures/sample_project');
+
+      if (result.stdout.includes('No spec files to run')) {
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Running shard 4/4');
+        expect(result.stdout).toContain('No spec files to run in this shard');
+      } else {
+        // If this shard isn't empty, that's also valid
+        expect(result.stdout).toContain('Running shard 4/4');
+        expect(result.stdout).toContain('Loaded');
+      }
+    });
+  });
+});

--- a/spec/sharded_runner_spec.js
+++ b/spec/sharded_runner_spec.js
@@ -26,6 +26,13 @@ describe('ShardedRunner', function() {
     this.mockJasmineCore = {
       noGlobals: function() {
         return this.mockJasmineInterface;
+      }.bind(this),
+      boot: function() {
+        return {
+          getEnv: function() {
+            return this.mockEnv;
+          }.bind(this)
+        };
       }.bind(this)
     };
 
@@ -288,6 +295,20 @@ describe('ShardedRunner', function() {
       this.runner.exitOnCompletion = false;
 
       await expectAsync(this.runner.execute()).toBeResolved();
+    });
+
+    it('supports globals: false option', async function() {
+      const runner = new ShardedRunner({
+        jasmineCore: this.mockJasmineCore,
+        shardIndex: 0,
+        shardCount: 4,
+        globals: false
+      });
+      runner.exitOnCompletion = false;
+
+      const result = await runner.execute();
+      expect(result).toBeDefined();
+      expect(result.overallStatus).toBe('passed');
     });
   });
 

--- a/spec/sharded_runner_spec.js
+++ b/spec/sharded_runner_spec.js
@@ -1,0 +1,373 @@
+const path = require('path');
+const ShardedRunner = require('../lib/sharded_runner');
+
+describe('ShardedRunner', function() {
+  beforeEach(function() {
+    // Mock jasmine-core environment
+    this.mockEnv = {
+      configure: function() {},
+      addReporter: function() {},
+      execute: function() {
+        return Promise.resolve({ overallStatus: 'passed' });
+      }
+    };
+
+    this.mockJasmineInterface = {
+      jasmine: { 
+        getEnv: function() {
+          return this.mockEnv;
+        }.bind(this)
+      },
+      describe: function() {},
+      it: function() {},
+      beforeEach: function() {},
+      afterEach: function() {}
+    };
+
+    this.mockJasmineCore = {
+      noGlobals: function() {
+        return this.mockJasmineInterface;
+      }.bind(this)
+    };
+
+    this.runner = new ShardedRunner({
+      jasmineCore: this.mockJasmineCore,
+      shardIndex: 0,
+      shardCount: 4
+    });
+
+    // Mock file system operations without spyOn
+    this.originalExistsSync = require('fs').existsSync;
+    this.originalReadFileSync = require('fs').readFileSync;
+    this.originalGlobSync = require('glob').sync;
+    
+    require('fs').existsSync = function() { return true; };
+    require('fs').readFileSync = function() { return '{}'; };
+    require('glob').sync = function() { return []; };
+  });
+
+  afterEach(function() {
+    // Restore original functions
+    require('fs').existsSync = this.originalExistsSync;
+    require('fs').readFileSync = this.originalReadFileSync;
+    require('glob').sync = this.originalGlobSync;
+  });
+
+  describe('constructor', function() {
+    it('initializes with provided options', function() {
+      const runner = new ShardedRunner({
+        jasmineCore: this.mockJasmineCore,
+        shardIndex: 2,
+        shardCount: 8
+      });
+
+      expect(runner.jasmineCore).toBe(this.mockJasmineCore);
+      expect(runner.shardIndex).toBe(2);
+      expect(runner.shardCount).toBe(8);
+      expect(runner.exitOnCompletion).toBe(true);
+    });
+
+    it('sets default values', function() {
+      expect(this.runner.specFiles).toEqual([]);
+      expect(this.runner.helperFiles).toEqual([]);
+      expect(this.runner.requireFiles).toEqual([]);
+      expect(this.runner.specDir).toBe('spec');
+    });
+  });
+
+  describe('filterFilesToShard', function() {
+    it('returns empty array for empty input', function() {
+      expect(this.runner.filterFilesToShard([])).toEqual([]);
+      expect(this.runner.filterFilesToShard(null)).toEqual([]);
+    });
+
+    it('distributes files using round-robin algorithm', function() {
+      const files = [
+        'spec1.js', 'spec2.js', 'spec3.js', 'spec4.js',
+        'spec5.js', 'spec6.js', 'spec7.js', 'spec8.js'
+      ];
+
+      // Test shard 0 (index 0) of 4 shards - should get files at indices 0, 4
+      this.runner.shardIndex = 0;
+      this.runner.shardCount = 4;
+      const shard0Files = this.runner.filterFilesToShard(files);
+      expect(shard0Files).toEqual(['spec1.js', 'spec5.js']);
+
+      // Test shard 1 (index 1) of 4 shards - should get files at indices 1, 5
+      this.runner.shardIndex = 1;
+      const shard1Files = this.runner.filterFilesToShard(files);
+      expect(shard1Files).toEqual(['spec2.js', 'spec6.js']);
+
+      // Test shard 2 (index 2) of 4 shards - should get files at indices 2, 6
+      this.runner.shardIndex = 2;
+      const shard2Files = this.runner.filterFilesToShard(files);
+      expect(shard2Files).toEqual(['spec3.js', 'spec7.js']);
+
+      // Test shard 3 (index 3) of 4 shards - should get files at indices 3, 7
+      this.runner.shardIndex = 3;
+      const shard3Files = this.runner.filterFilesToShard(files);
+      expect(shard3Files).toEqual(['spec4.js', 'spec8.js']);
+    });
+
+    it('handles uneven distribution correctly', function() {
+      const files = ['spec1.js', 'spec2.js', 'spec3.js', 'spec4.js', 'spec5.js'];
+
+      this.runner.shardCount = 3;
+
+      // Shard 0 should get files at indices 0, 3
+      this.runner.shardIndex = 0;
+      expect(this.runner.filterFilesToShard(files)).toEqual(['spec1.js', 'spec4.js']);
+
+      // Shard 1 should get files at indices 1, 4
+      this.runner.shardIndex = 1;
+      expect(this.runner.filterFilesToShard(files)).toEqual(['spec2.js', 'spec5.js']);
+
+      // Shard 2 should get file at index 2
+      this.runner.shardIndex = 2;
+      expect(this.runner.filterFilesToShard(files)).toEqual(['spec3.js']);
+    });
+
+    it('sorts files deterministically before distribution', function() {
+      const unsortedFiles = ['zebra.js', 'apple.js', 'banana.js', 'cherry.js'];
+      const expectedSortedOrder = ['apple.js', 'cherry.js', , 'banana.js', 'zebra.js'];
+
+      this.runner.shardIndex = 0;
+      this.runner.shardCount = 2;
+
+      const result = this.runner.filterFilesToShard(unsortedFiles);
+      expect(result).toEqual(expectedSortedOrder.slice(0,2));
+    });
+
+    it('handles more shards than files', function() {
+      const files = ['spec1.js', 'spec2.js'];
+      this.runner.shardCount = 4;
+
+      // Shard 0 gets spec1.js, shard 1 gets spec2.js, shards 2&3 get nothing
+      this.runner.shardIndex = 0;
+      expect(this.runner.filterFilesToShard(files)).toEqual(['spec1.js']);
+
+      this.runner.shardIndex = 1;
+      expect(this.runner.filterFilesToShard(files)).toEqual(['spec2.js']);
+
+      this.runner.shardIndex = 2;
+      expect(this.runner.filterFilesToShard(files)).toEqual([]);
+
+      this.runner.shardIndex = 3;
+      expect(this.runner.filterFilesToShard(files)).toEqual([]);
+    });
+  });
+
+  describe('loadConfigFile', function() {
+    it('loads valid configuration file', async function() {
+      const config = {
+        spec_dir: 'spec',
+        spec_files: ['*_spec.js'],
+        helpers: ['helper.js'],
+        requires: ['some-module'],
+        random: true,
+        seed: 12345
+      };
+
+      require('fs').readFileSync = function() { return JSON.stringify(config); };
+      require('glob').sync = function() { 
+        return ['/abs/path/test1_spec.js', '/abs/path/test2_spec.js', '/abs/path/helper.js'];
+      };
+
+      await this.runner.loadConfigFile('jasmine.json');
+
+      expect(this.runner.specDir).toBe('spec');
+      expect(this.runner.requireFiles).toEqual(['some-module']);
+      expect(this.runner.jasmineConfig.random).toBe(true);
+      expect(this.runner.jasmineConfig.seed).toBe(12345);
+    });
+
+    it('throws error for non-existent config file', async function() {
+      require('fs').existsSync = function() { return false; };
+
+      await expectAsync(this.runner.loadConfigFile('nonexistent.json'))
+        .toBeRejectedWithError(/Config file not found/);
+    });
+
+    it('throws error for invalid JSON', async function() {
+      require('fs').readFileSync = function() { return '{ invalid json }'; };
+
+      await expectAsync(this.runner.loadConfigFile('invalid.json'))
+        .toBeRejectedWithError(/Failed to parse config file/);
+    });
+
+    it('applies shard filtering only to spec files', async function() {
+      const config = {
+        spec_dir: 'spec',
+        spec_files: ['*_spec.js'],
+        helpers: ['helper.js']
+      };
+
+      require('fs').readFileSync = function() { return JSON.stringify(config); };
+      
+      // Mock glob to return different results for different patterns
+      require('glob').sync = function(pattern) {
+        if (pattern === '*_spec.js') {
+          return ['/abs/path/test1_spec.js', '/abs/path/test2_spec.js'];
+        } else if (pattern === 'helper.js') {
+          return ['/abs/path/helper.js'];
+        }
+        return [];
+      };
+
+      this.runner.shardIndex = 0;
+      this.runner.shardCount = 2;
+
+      await this.runner.loadConfigFile('jasmine.json');
+
+      // Spec files should be filtered by shard (1 of 2 files)
+      expect(this.runner.specFiles.length).toBe(1);
+
+      // Helper files should NOT be filtered (all shards get all helpers)
+      expect(this.runner.helperFiles.length).toBe(1);
+      expect(this.runner.helperFiles[0]).toMatch(/helper\.js$/);
+    });
+  });
+
+  describe('addMatchingFiles', function() {
+    it('finds files matching include patterns', function() {
+      this.runner.specDir = 'spec';
+      require('glob').sync = function() { return ['/abs/path/test1.js', '/abs/path/test2.js']; };
+      
+      const files = this.runner.addMatchingFiles(['test*.js']);
+
+      expect(files.length).toBe(2);
+      expect(files.some(f => f.includes('test1.js'))).toBe(true);
+      expect(files.some(f => f.includes('test2.js'))).toBe(true);
+    });
+
+    it('excludes files matching exclude patterns', function() {
+      this.runner.specDir = 'spec';
+      require('glob').sync = function() { return ['/abs/path/test1.js', '/abs/path/test2.js']; };
+      
+      const files = this.runner.addMatchingFiles(['*.js', '!ignore_*.js']);
+
+      expect(files.length).toBe(2);
+      expect(files.some(f => f.includes('ignore_me.js'))).toBe(false);
+    });
+
+    it('returns absolute paths', function() {
+      this.runner.specDir = 'spec';
+      require('glob').sync = function() { return ['/abs/path/test1.js']; };
+      
+      const files = this.runner.addMatchingFiles(['test1.js']);
+
+      expect(files.length).toBe(1);
+      expect(path.isAbsolute(files[0])).toBe(true);
+    });
+
+    it('removes duplicates', function() {
+      this.runner.specDir = 'spec';
+      require('glob').sync = function() { return ['/abs/path/test1.js', '/abs/path/test2.js']; };
+      
+      const files = this.runner.addMatchingFiles(['test1.js', 'test*.js']);
+
+      // Should not have duplicates even though test1.js matches both patterns
+      const test1Files = files.filter(f => f.includes('test1.js'));
+      expect(test1Files.length).toBe(1);
+    });
+  });
+
+  describe('execute', function() {
+    it('sets up jasmine environment correctly', async function() {
+      this.runner.exitOnCompletion = false; // Don't exit in tests
+
+      const result = await this.runner.execute();
+
+      // Verify it returns the expected result structure
+      expect(result).toBeDefined();
+      expect(result.overallStatus).toBe('passed');
+    });
+
+    it('sets up global functions', async function() {
+      this.runner.exitOnCompletion = false;
+
+      await this.runner.execute();
+
+      // Verify global functions are set
+      expect(typeof globalThis.describe).toBe('function');
+      expect(typeof globalThis.it).toBe('function');
+      expect(typeof globalThis.beforeEach).toBe('function');
+      expect(typeof globalThis.afterEach).toBe('function');
+    });
+
+    it('handles execution without errors', async function() {
+      this.runner.exitOnCompletion = false;
+
+      // Should not throw
+      await expectAsync(this.runner.execute()).toBeResolved();
+    });
+
+    it('handles require files without errors', async function() {
+      this.runner.requireFiles = []; // Empty array to avoid requiring actual modules
+      this.runner.exitOnCompletion = false;
+
+      await expectAsync(this.runner.execute()).toBeResolved();
+    });
+  });
+
+  describe('mathematical distribution correctness', function() {
+    it('distributes 108 files across 4 shards correctly', function() {
+      // Create array of 108 files (the example from summary)
+      const files = Array.from({length: 108}, (_, i) => `spec${i + 1}.js`);
+
+      const results = [];
+      for (let shard = 0; shard < 4; shard++) {
+        this.runner.shardIndex = shard;
+        this.runner.shardCount = 4;
+        const shardFiles = this.runner.filterFilesToShard(files);
+        results.push(shardFiles.length);
+      }
+
+      // Should be 27 files per shard for perfect distribution
+      expect(results).toEqual([27, 27, 27, 27]);
+    });
+
+    it('distributes 108 files across 8 shards correctly', function() {
+      const files = Array.from({length: 108}, (_, i) => `spec${i + 1}.js`);
+
+      const results = [];
+      for (let shard = 0; shard < 8; shard++) {
+        this.runner.shardIndex = shard;
+        this.runner.shardCount = 8;
+        const shardFiles = this.runner.filterFilesToShard(files);
+        results.push(shardFiles.length);
+      }
+
+      // 108 / 8 = 13.5, so we expect 6 shards with 14 files and 2 with 13
+      const expected = [14, 14, 14, 14, 13, 13, 13, 13];
+      expect(results).toEqual(expected);
+    });
+
+    it('ensures all files are distributed exactly once', function() {
+      const files = Array.from({length: 25}, (_, i) => `spec${i + 1}.js`);
+      const shardCount = 4;
+
+      const allShardFiles = [];
+      for (let shard = 0; shard < shardCount; shard++) {
+        this.runner.shardIndex = shard;
+        this.runner.shardCount = shardCount;
+        const shardFiles = this.runner.filterFilesToShard(files);
+        allShardFiles.push(...shardFiles);
+      }
+
+      // All files should be included exactly once
+      expect(allShardFiles.sort()).toEqual(files.sort());
+    });
+
+    it('maintains deterministic ordering across multiple runs', function() {
+      const files = ['zebra.js', 'apple.js', 'banana.js', 'cherry.js'];
+      this.runner.shardIndex = 0;
+      this.runner.shardCount = 2;
+
+      const result1 = this.runner.filterFilesToShard(files);
+      const result2 = this.runner.filterFilesToShard(files);
+
+      expect(result1).toEqual(result2);
+    });
+  });
+});


### PR DESCRIPTION
# Add ShardedRunner for CI test parallelization

  Adds file-based test sharding to distribute spec files across multiple
  CI processes or jobs.

  ## Features

  - **File-based distribution**: Uses deterministic round-robin to
  distribute spec files (not individual specs) across shards
  - **1-based CLI interface**: `jasmine-sharded --shard=1/4` syntax
  matching common CI patterns
  - **Jasmine config compatibility**: Reads standard `jasmine.json`
  configuration files
  - **Helper file handling**: All shards load all helpers for consistent
  test environments
  - **Empty shard support**: Gracefully handles shards with no files to
  run

  ## Usage

  ```bash
  # Run shard 1 of 4 total shards
  node bin/jasmine-sharded.js --shard=1/4

  # Use custom config file
  node bin/jasmine-sharded.js --shard=2/4 --config=test/jasmine.json

  Implementation

  - lib/sharded_runner.js - Core sharding logic with jasmine-core
  integration
  - bin/jasmine-sharded.js - CLI interface with argument validation
  - Exported as require('jasmine/sharded') for programmatic use
  - 37 comprehensive tests covering distribution algorithms and CLI
  interface

  Benefits

  - Reduces CI test times through parallel execution
  - No changes to existing test files required
  - Deterministic file distribution ensures consistent shard contents
  - Integrates seamlessly with existing jasmine-npm patterns